### PR TITLE
fix: align workflow/activity semantics with mainline Temporal SDKs

### DIFF
--- a/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalCoreClient.kt
+++ b/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalCoreClient.kt
@@ -5,6 +5,7 @@ import com.google.protobuf.MessageLite
 import com.surrealdev.temporal.core.internal.ClientCallbackDispatcher
 import com.surrealdev.temporal.core.internal.ClientTlsOptions
 import com.surrealdev.temporal.core.internal.FactoryArenaScope
+import com.surrealdev.temporal.core.internal.nativeCallbackException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.slf4j.LoggerFactory
 import java.lang.foreign.Arena
@@ -144,7 +145,7 @@ class TemporalCoreClient private constructor(
                                 try {
                                     when {
                                         error != null -> {
-                                            continuation.resumeWithException(TemporalCoreException(error))
+                                            continuation.resumeWithException(nativeCallbackException(error))
                                         }
 
                                         clientPtr != null -> {
@@ -153,7 +154,7 @@ class TemporalCoreClient private constructor(
 
                                         else -> {
                                             continuation.resumeWithException(
-                                                TemporalCoreException("Connect returned null without error"),
+                                                nativeCallbackException("Connect returned null without error"),
                                             )
                                         }
                                     }

--- a/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalDevServer.kt
+++ b/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalDevServer.kt
@@ -3,6 +3,7 @@ package com.surrealdev.temporal.core
 import com.surrealdev.temporal.core.internal.EphemeralServerCallbackDispatcher
 import com.surrealdev.temporal.core.internal.FactoryArenaScope
 import com.surrealdev.temporal.core.internal.TemporalCoreEphemeralServer
+import com.surrealdev.temporal.core.internal.nativeCallbackException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.lang.foreign.Arena
 import java.lang.foreign.MemorySegment
@@ -97,10 +98,10 @@ class TemporalDevServer private constructor(
                         ) { serverPtr, targetUrl, error ->
                             try {
                                 if (error != null) {
-                                    continuation.resumeWithException(TemporalCoreException(error))
+                                    continuation.resumeWithException(nativeCallbackException(error))
                                 } else if (serverPtr == null || targetUrl == null) {
                                     continuation.resumeWithException(
-                                        TemporalCoreException("Server start returned null without error"),
+                                        nativeCallbackException("Server start returned null without error"),
                                     )
                                 } else {
                                     continuation.resume(Pair(serverPtr, targetUrl))
@@ -179,10 +180,10 @@ class TemporalDevServer private constructor(
             ) { serverPtr, targetUrl, error ->
                 try {
                     if (error != null) {
-                        future.completeExceptionally(TemporalCoreException(error))
+                        future.completeExceptionally(nativeCallbackException(error))
                     } else if (serverPtr == null || targetUrl == null) {
                         future.completeExceptionally(
-                            TemporalCoreException("Dev server start returned null without error"),
+                            nativeCallbackException("Dev server start returned null without error"),
                         )
                     } else {
                         ownershipTransferred.set(true)
@@ -238,7 +239,7 @@ class TemporalDevServer private constructor(
                 dispatcher = dispatcher,
             ) { error ->
                 if (error != null) {
-                    shutdownFuture.completeExceptionally(TemporalCoreException(error))
+                    shutdownFuture.completeExceptionally(nativeCallbackException(error))
                 } else {
                     shutdownFuture.complete(Unit)
                 }

--- a/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalTestServer.kt
+++ b/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalTestServer.kt
@@ -6,6 +6,7 @@ import com.google.protobuf.timestamp
 import com.surrealdev.temporal.core.internal.EphemeralServerCallbackDispatcher
 import com.surrealdev.temporal.core.internal.FactoryArenaScope
 import com.surrealdev.temporal.core.internal.TemporalCoreEphemeralServer
+import com.surrealdev.temporal.core.internal.nativeCallbackException
 import io.temporal.api.testservice.v1.GetCurrentTimeResponse
 import io.temporal.api.testservice.v1.LockTimeSkippingRequest
 import io.temporal.api.testservice.v1.SleepRequest
@@ -111,10 +112,10 @@ class TemporalTestServer private constructor(
                             ) { serverPtr, targetUrl, error ->
                                 try {
                                     if (error != null) {
-                                        continuation.resumeWithException(TemporalCoreException(error))
+                                        continuation.resumeWithException(nativeCallbackException(error))
                                     } else if (serverPtr == null || targetUrl == null) {
                                         continuation.resumeWithException(
-                                            TemporalCoreException("Test server start returned null without error"),
+                                            nativeCallbackException("Test server start returned null without error"),
                                         )
                                     } else {
                                         continuation.resume(Pair(serverPtr, targetUrl))
@@ -307,7 +308,7 @@ class TemporalTestServer private constructor(
                 dispatcher = dispatcher,
             ) { error ->
                 if (error != null) {
-                    shutdownFuture.completeExceptionally(TemporalCoreException(error))
+                    shutdownFuture.completeExceptionally(nativeCallbackException(error))
                 } else {
                     shutdownFuture.complete(Unit)
                 }

--- a/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalWorker.kt
+++ b/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/TemporalWorker.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.CodedInputStream
 import com.google.protobuf.MessageLite
 import com.surrealdev.temporal.core.internal.FactoryArenaScope
 import com.surrealdev.temporal.core.internal.WorkerCallbackDispatcher
+import com.surrealdev.temporal.core.internal.nativeCallbackException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.slf4j.LoggerFactory
 import java.lang.foreign.Arena
@@ -128,7 +129,7 @@ class TemporalWorker private constructor(
             val callback =
                 InternalWorker.WorkerCallback { error ->
                     if (error != null) {
-                        continuation.resumeWithException(TemporalCoreException(error))
+                        continuation.resumeWithException(nativeCallbackException(error))
                     } else {
                         continuation.resume(Unit)
                     }
@@ -156,7 +157,7 @@ class TemporalWorker private constructor(
                 val callback =
                     com.surrealdev.temporal.core.internal.TemporalCoreFfmUtil.TypedCallback<T> { data, error ->
                         when {
-                            error != null -> continuation.resumeWithException(TemporalCoreException(error))
+                            error != null -> continuation.resumeWithException(nativeCallbackException(error))
                             else -> continuation.resume(data)
                         }
                     }
@@ -188,7 +189,7 @@ class TemporalWorker private constructor(
                 val callback =
                     com.surrealdev.temporal.core.internal.TemporalCoreFfmUtil.TypedCallback<T> { data, error ->
                         when {
-                            error != null -> continuation.resumeWithException(TemporalCoreException(error))
+                            error != null -> continuation.resumeWithException(nativeCallbackException(error))
                             else -> continuation.resume(data)
                         }
                     }
@@ -310,7 +311,7 @@ class TemporalWorker private constructor(
             val callback =
                 InternalWorker.WorkerCallback { error ->
                     if (error != null) {
-                        continuation.resumeWithException(TemporalCoreException(error))
+                        continuation.resumeWithException(nativeCallbackException(error))
                     } else {
                         continuation.resume(Unit)
                     }

--- a/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/internal/BaseCallbackDispatcher.kt
+++ b/core-bridge/src/main/kotlin/com/surrealdev/temporal/core/internal/BaseCallbackDispatcher.kt
@@ -8,6 +8,27 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
+ * Builds a [TemporalCoreException] WITHOUT capturing a stack trace.
+ *
+ * MUST be used for every exception constructed on a native (FFM upcall) callback
+ * thread: the trace is meaningless there (it shows the Rust callback thread, not
+ * user code), and the JVM's stack walk over upcall stub frames has proven
+ * crash-prone (SIGSEGV in `Throwable.fillInStackTrace` on macOS aarch64).
+ */
+internal fun nativeCallbackException(
+    message: String,
+    errorType: String? = null,
+    statusCode: Int? = null,
+): TemporalCoreException =
+    TemporalCoreException(
+        message = message,
+        errorType = errorType,
+        statusCode = statusCode,
+        cause = null,
+        writableStackTrace = false,
+    )
+
+/**
  * Base class for callback dispatchers that manage FFM native callbacks.
  *
  * Provides shared functionality for:
@@ -68,7 +89,7 @@ internal abstract class BaseCallbackDispatcher(
 
                 statusCode != 0 -> {
                     resumeWithException(
-                        TemporalCoreException(
+                        nativeCallbackException(
                             message = failureMessage ?: "RPC call failed with status $statusCode",
                             statusCode = statusCode,
                         ),
@@ -77,7 +98,7 @@ internal abstract class BaseCallbackDispatcher(
 
                 else -> {
                     resumeWithException(
-                        TemporalCoreException("RPC call returned null response"),
+                        nativeCallbackException("RPC call returned null response"),
                     )
                 }
             }
@@ -92,7 +113,7 @@ internal abstract class BaseCallbackDispatcher(
     fun CancellableContinuation<Unit>.resumeWorkerResult(error: String?) {
         try {
             if (error != null) {
-                resumeWithException(TemporalCoreException(error))
+                resumeWithException(nativeCallbackException(error))
             } else {
                 resume(Unit)
             }
@@ -110,9 +131,9 @@ internal abstract class BaseCallbackDispatcher(
     ) {
         try {
             when {
-                error != null -> resumeWithException(TemporalCoreException(error))
+                error != null -> resumeWithException(nativeCallbackException(error))
                 result != null -> resume(result)
-                else -> resumeWithException(TemporalCoreException("Operation returned null without error"))
+                else -> resumeWithException(nativeCallbackException("Operation returned null without error"))
             }
         } catch (_: IllegalStateException) {
             // Continuation already resumed, ignore

--- a/core-common/src/main/kotlin/com/surrealdev/temporal/core/TemporalCoreException.kt
+++ b/core-common/src/main/kotlin/com/surrealdev/temporal/core/TemporalCoreException.kt
@@ -4,13 +4,21 @@ package com.surrealdev.temporal.core
  * Exception thrown when an error occurs in the Temporal Core native bridge.
  *
  * This exception wraps errors that originate from the Rust side of the FFI boundary.
+ *
+ * @param writableStackTrace Whether to capture a stack trace at construction.
+ *   Constructions on native (FFM upcall) callback threads MUST pass false: the trace
+ *   is meaningless there (it shows the Rust callback thread, not user code), and the
+ *   JVM's stack walk over upcall stub frames has proven crash-prone (SIGSEGV in
+ *   `Throwable.fillInStackTrace` on macOS aarch64). Callers on normal JVM threads can
+ *   keep the default.
  */
 class TemporalCoreException(
     message: String,
     val errorType: String? = null,
     val statusCode: Int? = null,
     cause: Throwable? = null,
-) : RuntimeException(message, cause) {
+    writableStackTrace: Boolean = true,
+) : RuntimeException(message, cause, true, writableStackTrace) {
     override fun toString(): String =
         buildString {
             append("TemporalCoreException")

--- a/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/TemporalTestClient.kt
+++ b/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/TemporalTestClient.kt
@@ -208,4 +208,11 @@ internal class TimeSkippingWorkflowHandle(
     override suspend fun describe() = delegate.describe()
 
     override suspend fun getHistory(): WorkflowHistory = delegate.getHistory()
+
+    override fun fetchHistoryEvents(
+        waitNewEvent: Boolean,
+    ): kotlinx.coroutines.flow.Flow<
+        com.surrealdev.temporal.client.history.TemporalHistoryEvent,
+    > =
+        delegate.fetchHistoryEvents(waitNewEvent)
 }

--- a/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/WorkflowAssertions.kt
+++ b/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/WorkflowAssertions.kt
@@ -2,6 +2,11 @@ package com.surrealdev.temporal.testing
 
 import com.surrealdev.temporal.client.WorkflowHandle
 import com.surrealdev.temporal.client.history.WorkflowHistory
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /**
  * DSL for making assertions about workflow execution history.
@@ -255,4 +260,43 @@ suspend fun WorkflowHandle.assertHistoryAndReturn(assertions: HistoryAssertionSc
     scope.assertions()
     scope.validate()
     return history
+}
+
+/**
+ * Polls the workflow history until [predicate] matches, returning the matching history.
+ *
+ * Use this to await a non-terminal history condition (e.g. a WorkflowTaskFailed event
+ * appearing while the workflow keeps running) where [WorkflowHandle.result]'s close-event
+ * long poll doesn't apply.
+ *
+ * Example:
+ * ```kotlin
+ * val history = handle.awaitHistory(description = "a WorkflowTaskFailed event") {
+ *     it.filterByType<TemporalHistoryEvent.WorkflowTaskFailed>().isNotEmpty()
+ * }
+ * ```
+ *
+ * @param timeout Maximum time to wait before failing the test
+ * @param pollInterval Delay between history fetches
+ * @param description Shown in the failure message when the timeout elapses
+ * @throws AssertionError if the predicate doesn't match within [timeout]
+ */
+suspend fun WorkflowHandle.awaitHistory(
+    timeout: Duration = 10.seconds,
+    pollInterval: Duration = 200.milliseconds,
+    description: String = "history condition",
+    predicate: (WorkflowHistory) -> Boolean,
+): WorkflowHistory {
+    val deadline = TimeSource.Monotonic.markNow() + timeout
+    var last: WorkflowHistory? = null
+    while (deadline.hasNotPassedNow()) {
+        val history = getHistory()
+        last = history
+        if (predicate(history)) return history
+        delay(pollInterval)
+    }
+    throw AssertionError(
+        "Timed out after $timeout waiting for $description. " +
+            "Last seen events: ${last?.events?.map { it::class.simpleName }}",
+    )
 }

--- a/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/WorkflowAssertions.kt
+++ b/core-testing/src/main/kotlin/com/surrealdev/temporal/testing/WorkflowAssertions.kt
@@ -1,12 +1,13 @@
 package com.surrealdev.temporal.testing
 
 import com.surrealdev.temporal.client.WorkflowHandle
+import com.surrealdev.temporal.client.history.TemporalHistoryEvent
 import com.surrealdev.temporal.client.history.WorkflowHistory
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeSource
 
 /**
  * DSL for making assertions about workflow execution history.
@@ -263,11 +264,13 @@ suspend fun WorkflowHandle.assertHistoryAndReturn(assertions: HistoryAssertionSc
 }
 
 /**
- * Polls the workflow history until [predicate] matches, returning the matching history.
+ * Awaits a history condition, returning the matching history.
  *
- * Use this to await a non-terminal history condition (e.g. a WorkflowTaskFailed event
- * appearing while the workflow keeps running) where [WorkflowHandle.result]'s close-event
- * long poll doesn't apply.
+ * Streams events via [WorkflowHandle.fetchHistoryEvents] with server-side long polling
+ * (no client-side sleep loop) and evaluates [predicate] against the accumulated history
+ * after each event. Use this to await a non-terminal history condition (e.g. a
+ * WorkflowTaskFailed event appearing while the workflow keeps running) where
+ * [WorkflowHandle.result]'s close-event long poll doesn't apply.
  *
  * Example:
  * ```kotlin
@@ -277,26 +280,26 @@ suspend fun WorkflowHandle.assertHistoryAndReturn(assertions: HistoryAssertionSc
  * ```
  *
  * @param timeout Maximum time to wait before failing the test
- * @param pollInterval Delay between history fetches
  * @param description Shown in the failure message when the timeout elapses
- * @throws AssertionError if the predicate doesn't match within [timeout]
+ * @throws AssertionError if the predicate doesn't match within [timeout] (or the
+ *   workflow closes without it ever matching)
  */
 suspend fun WorkflowHandle.awaitHistory(
     timeout: Duration = 10.seconds,
-    pollInterval: Duration = 200.milliseconds,
     description: String = "history condition",
     predicate: (WorkflowHistory) -> Boolean,
 ): WorkflowHistory {
-    val deadline = TimeSource.Monotonic.markNow() + timeout
-    var last: WorkflowHistory? = null
-    while (deadline.hasNotPassedNow()) {
-        val history = getHistory()
-        last = history
-        if (predicate(history)) return history
-        delay(pollInterval)
-    }
-    throw AssertionError(
+    val events = mutableListOf<TemporalHistoryEvent>()
+    val matched =
+        withTimeoutOrNull(timeout) {
+            fetchHistoryEvents(waitNewEvent = true)
+                .map { event ->
+                    events.add(event)
+                    WorkflowHistory(workflowId, runId, events.toList())
+                }.firstOrNull { predicate(it) }
+        }
+    return matched ?: throw AssertionError(
         "Timed out after $timeout waiting for $description. " +
-            "Last seen events: ${last?.events?.map { it::class.simpleName }}",
+            "Seen events: ${events.map { it::class.simpleName }}",
     )
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1494,15 +1494,18 @@ public final class com/surrealdev/temporal/application/plugin/interceptor/Schedu
 }
 
 public final class com/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput {
-	public synthetic fun <init> (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2-LsIyt50 ()Lio/temporal/api/common/v1/Payloads;
 	public final fun component3 ()Lcom/surrealdev/temporal/workflow/ActivityOptions;
-	public final fun copy-7Kc-crE (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;)Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;
-	public static synthetic fun copy-7Kc-crE$default (Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;ILjava/lang/Object;)Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy-vMcdwC0 (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Ljava/util/Map;)Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;
+	public static synthetic fun copy-vMcdwC0$default (Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Ljava/util/Map;ILjava/lang/Object;)Lcom/surrealdev/temporal/application/plugin/interceptor/ScheduleActivityInput;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivityType ()Ljava/lang/String;
 	public final fun getArgs-LsIyt50 ()Lio/temporal/api/common/v1/Payloads;
+	public final fun getHeaders ()Ljava/util/Map;
 	public final fun getOptions ()Lcom/surrealdev/temporal/workflow/ActivityOptions;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1595,12 +1598,15 @@ public final class com/surrealdev/temporal/application/plugin/interceptor/Sleep 
 }
 
 public final class com/surrealdev/temporal/application/plugin/interceptor/SleepInput {
-	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UwyO8pc ()J
-	public final fun copy-LRDsOJo (J)Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;
-	public static synthetic fun copy-LRDsOJo$default (Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;JILjava/lang/Object;)Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-VtjQ1oo (JLjava/lang/String;)Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;
+	public static synthetic fun copy-VtjQ1oo$default (Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;JLjava/lang/String;ILjava/lang/Object;)Lcom/surrealdev/temporal/application/plugin/interceptor/SleepInput;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDuration-UwyO8pc ()J
+	public final fun getSummary ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4361,12 +4367,13 @@ public final class com/surrealdev/temporal/workflow/ActivityHandle$DefaultImpls 
 }
 
 public final class com/surrealdev/temporal/workflow/ActivityOptions {
-	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-FghU774 ()Lkotlin/time/Duration;
 	public final fun component10 ()Ljava/util/Map;
 	public final fun component11 ()I
 	public final fun component12 ()Z
+	public final fun component13 ()Ljava/lang/String;
 	public final fun component2-FghU774 ()Lkotlin/time/Duration;
 	public final fun component3-FghU774 ()Lkotlin/time/Duration;
 	public final fun component4-FghU774 ()Lkotlin/time/Duration;
@@ -4375,8 +4382,8 @@ public final class com/surrealdev/temporal/workflow/ActivityOptions {
 	public final fun component7 ()Lcom/surrealdev/temporal/common/RetryPolicy;
 	public final fun component8 ()Lcom/surrealdev/temporal/workflow/ActivityCancellationType;
 	public final fun component9 ()Lcom/surrealdev/temporal/workflow/VersioningIntent;
-	public final fun copy-_R-IIuk (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZ)Lcom/surrealdev/temporal/workflow/ActivityOptions;
-	public static synthetic fun copy-_R-IIuk$default (Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/ActivityOptions;
+	public final fun copy-7_HE9y0 (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZLjava/lang/String;)Lcom/surrealdev/temporal/workflow/ActivityOptions;
+	public static synthetic fun copy-7_HE9y0$default (Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ActivityCancellationType;Lcom/surrealdev/temporal/workflow/VersioningIntent;Ljava/util/Map;IZLjava/lang/String;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/ActivityOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivityId ()Ljava/lang/String;
 	public final fun getCancellationType ()Lcom/surrealdev/temporal/workflow/ActivityCancellationType;
@@ -4388,6 +4395,7 @@ public final class com/surrealdev/temporal/workflow/ActivityOptions {
 	public final fun getScheduleToCloseTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getScheduleToStartTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getStartToCloseTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getSummary ()Ljava/lang/String;
 	public final fun getTaskQueue ()Ljava/lang/String;
 	public final fun getVersioningIntent ()Lcom/surrealdev/temporal/workflow/VersioningIntent;
 	public fun hashCode ()I
@@ -4420,9 +4428,15 @@ public final class com/surrealdev/temporal/workflow/ChildWorkflowHandle$DefaultI
 }
 
 public final class com/surrealdev/temporal/workflow/ChildWorkflowOptions {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;Lkotlin/time/Duration;Ljava/lang/String;Ljava/util/Map;Lcom/surrealdev/temporal/workflow/VersioningIntent;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;Lkotlin/time/Duration;Ljava/lang/String;Ljava/util/Map;Lcom/surrealdev/temporal/workflow/VersioningIntent;ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10-FghU774 ()Lkotlin/time/Duration;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component13 ()Lcom/surrealdev/temporal/workflow/VersioningIntent;
+	public final fun component14 ()I
+	public final fun component15 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3-FghU774 ()Lkotlin/time/Duration;
 	public final fun component4-FghU774 ()Lkotlin/time/Duration;
@@ -4431,18 +4445,24 @@ public final class com/surrealdev/temporal/workflow/ChildWorkflowOptions {
 	public final fun component7 ()Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;
 	public final fun component8 ()Lcom/surrealdev/temporal/common/TypedSearchAttributes;
 	public final fun component9 ()Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;
-	public final fun copy-imR-fxc (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;)Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;
-	public static synthetic fun copy-imR-fxc$default (Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;
+	public final fun copy-K9v0jNc (Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;Lkotlin/time/Duration;Ljava/lang/String;Ljava/util/Map;Lcom/surrealdev/temporal/workflow/VersioningIntent;ILjava/lang/String;)Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;
+	public static synthetic fun copy-K9v0jNc$default (Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;Ljava/lang/String;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/time/Duration;Lcom/surrealdev/temporal/common/RetryPolicy;Lcom/surrealdev/temporal/workflow/ParentClosePolicy;Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;Lcom/surrealdev/temporal/common/TypedSearchAttributes;Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;Lkotlin/time/Duration;Ljava/lang/String;Ljava/util/Map;Lcom/surrealdev/temporal/workflow/VersioningIntent;ILjava/lang/String;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCancellationType ()Lcom/surrealdev/temporal/workflow/ChildWorkflowCancellationType;
+	public final fun getCronSchedule ()Ljava/lang/String;
+	public final fun getMemo ()Ljava/util/Map;
 	public final fun getParentClosePolicy ()Lcom/surrealdev/temporal/workflow/ParentClosePolicy;
+	public final fun getPriority ()I
 	public final fun getRetryPolicy ()Lcom/surrealdev/temporal/common/RetryPolicy;
 	public final fun getSearchAttributes ()Lcom/surrealdev/temporal/common/TypedSearchAttributes;
+	public final fun getSummary ()Ljava/lang/String;
 	public final fun getTaskQueue ()Ljava/lang/String;
+	public final fun getVersioningIntent ()Lcom/surrealdev/temporal/workflow/VersioningIntent;
 	public final fun getWorkflowExecutionTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getWorkflowId ()Ljava/lang/String;
 	public final fun getWorkflowIdReusePolicy ()Lcom/surrealdev/temporal/client/WorkflowIdReusePolicy;
 	public final fun getWorkflowRunTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getWorkflowTaskTimeout-FghU774 ()Lkotlin/time/Duration;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4511,8 +4531,8 @@ public abstract interface class com/surrealdev/temporal/workflow/LocalActivityHa
 }
 
 public final class com/surrealdev/temporal/workflow/LocalActivityOptions {
-	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-FghU774 ()Lkotlin/time/Duration;
 	public final fun component2-FghU774 ()Lkotlin/time/Duration;
 	public final fun component3-FghU774 ()Lkotlin/time/Duration;
@@ -4520,8 +4540,9 @@ public final class com/surrealdev/temporal/workflow/LocalActivityOptions {
 	public final fun component5 ()Lcom/surrealdev/temporal/common/RetryPolicy;
 	public final fun component6-UwyO8pc ()J
 	public final fun component7 ()Lcom/surrealdev/temporal/workflow/ActivityCancellationType;
-	public final fun copy-Ujx4CJs (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;)Lcom/surrealdev/temporal/workflow/LocalActivityOptions;
-	public static synthetic fun copy-Ujx4CJs$default (Lcom/surrealdev/temporal/workflow/LocalActivityOptions;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/LocalActivityOptions;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy-ZDPINwc (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;Ljava/lang/String;)Lcom/surrealdev/temporal/workflow/LocalActivityOptions;
+	public static synthetic fun copy-ZDPINwc$default (Lcom/surrealdev/temporal/workflow/LocalActivityOptions;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/lang/String;Lcom/surrealdev/temporal/common/RetryPolicy;JLcom/surrealdev/temporal/workflow/ActivityCancellationType;Ljava/lang/String;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/LocalActivityOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActivityId ()Ljava/lang/String;
 	public final fun getCancellationType ()Lcom/surrealdev/temporal/workflow/ActivityCancellationType;
@@ -4530,6 +4551,7 @@ public final class com/surrealdev/temporal/workflow/LocalActivityOptions {
 	public final fun getScheduleToCloseTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getScheduleToStartTimeout-FghU774 ()Lkotlin/time/Duration;
 	public final fun getStartToCloseTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getSummary ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4571,6 +4593,7 @@ public abstract interface class com/surrealdev/temporal/workflow/WorkflowContext
 	public abstract fun awaitCondition-rnQQ1Ag (JLjava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitCondition-rnQQ1Ag$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;JLjava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun continueAsNewInternal (Lcom/surrealdev/temporal/workflow/ContinueAsNewOptions;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deprecatePatch (Ljava/lang/String;)V
 	public abstract fun getContinueAsNewSuggestedReasons ()Ljava/util/Set;
 	public abstract fun getExternalWorkflowHandle (Ljava/lang/String;Ljava/lang/String;)Lcom/surrealdev/temporal/workflow/ExternalWorkflowHandle;
 	public static synthetic fun getExternalWorkflowHandle$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/surrealdev/temporal/workflow/ExternalWorkflowHandle;
@@ -4593,7 +4616,8 @@ public abstract interface class com/surrealdev/temporal/workflow/WorkflowContext
 	public abstract fun setSignalHandlerWithPayloads (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public abstract fun setUpdateHandlerWithPayloads (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun setUpdateHandlerWithPayloads$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public abstract fun sleep-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sleep-KLykuaI (JLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sleep-KLykuaI$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun startActivityWithPayloads-vMcdwC0 (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun startActivityWithPayloads-vMcdwC0$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun startChildWorkflowWithPayloads-vMcdwC0 (Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -4613,6 +4637,7 @@ public final class com/surrealdev/temporal/workflow/WorkflowContext$DefaultImpls
 	public static fun plus (Lcom/surrealdev/temporal/workflow/WorkflowContext;Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
 	public static synthetic fun setDynamicUpdateHandlerWithPayloads$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static synthetic fun setUpdateHandlerWithPayloads$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun sleep-KLykuaI$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;JLjava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun startActivityWithPayloads-vMcdwC0$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ActivityOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun startChildWorkflowWithPayloads-vMcdwC0$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/ChildWorkflowOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun startLocalActivityWithPayloads-vMcdwC0$default (Lcom/surrealdev/temporal/workflow/WorkflowContext;Ljava/lang/String;Lio/temporal/api/common/v1/Payloads;Lcom/surrealdev/temporal/workflow/LocalActivityOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1930,6 +1930,8 @@ public final class com/surrealdev/temporal/client/WorkflowExecutionStatus$Compan
 public abstract interface class com/surrealdev/temporal/client/WorkflowHandle : com/surrealdev/temporal/workflow/WorkflowHandleBase {
 	public abstract fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun describe (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetchHistoryEvents (Z)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun fetchHistoryEvents$default (Lcom/surrealdev/temporal/client/WorkflowHandle;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getHistory (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getRunId ()Ljava/lang/String;
 	public abstract fun getSerializer ()Lcom/surrealdev/temporal/serialization/PayloadSerializer;
@@ -1944,6 +1946,7 @@ public abstract interface class com/surrealdev/temporal/client/WorkflowHandle : 
 }
 
 public final class com/surrealdev/temporal/client/WorkflowHandle$DefaultImpls {
+	public static synthetic fun fetchHistoryEvents$default (Lcom/surrealdev/temporal/client/WorkflowHandle;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun resultPayload-N4jGVcM$default (Lcom/surrealdev/temporal/client/WorkflowHandle;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun terminate$default (Lcom/surrealdev/temporal/client/WorkflowHandle;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/core/src/main/kotlin/com/surrealdev/temporal/application/plugin/interceptor/WorkflowOutboundInterceptors.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/application/plugin/interceptor/WorkflowOutboundInterceptors.kt
@@ -48,12 +48,14 @@ object ContinueAsNew : InterceptorHook<ContinueAsNewInput, Nothing> {
  * Input for the ScheduleActivity interceptor.
  *
  * Passed through the interceptor chain when a workflow schedules a remote activity.
- * Headers are available via [ActivityOptions.headers] and propagated to the proto command.
+ * Interceptors may add headers to [headers]; the proto command receives the merge of
+ * [ActivityOptions.headers] and [headers], with interceptor entries winning on collision.
  */
 data class ScheduleActivityInput(
     val activityType: String,
     val args: TemporalPayloads,
     val options: ActivityOptions,
+    val headers: MutableMap<String, TemporalPayload> = mutableMapOf(),
 )
 
 /**
@@ -89,6 +91,8 @@ data class StartChildWorkflowInput(
  */
 data class SleepInput(
     val duration: Duration,
+    /** Optional single-line summary shown for this timer in the Temporal UI. */
+    val summary: String? = null,
 )
 
 /**

--- a/core/src/main/kotlin/com/surrealdev/temporal/client/WorkflowHandle.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/client/WorkflowHandle.kt
@@ -19,6 +19,7 @@ import com.surrealdev.temporal.application.plugin.interceptor.StartWorkflowUpdat
 import com.surrealdev.temporal.application.plugin.interceptor.StartWorkflowUpdateInput
 import com.surrealdev.temporal.application.plugin.interceptor.TerminateWorkflow
 import com.surrealdev.temporal.application.plugin.interceptor.TerminateWorkflowInput
+import com.surrealdev.temporal.client.history.TemporalHistoryEvent
 import com.surrealdev.temporal.client.history.WorkflowHistory
 import com.surrealdev.temporal.client.internal.GRPC_CANCELLED
 import com.surrealdev.temporal.client.internal.GRPC_DEADLINE_EXCEEDED
@@ -53,6 +54,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import org.slf4j.LoggerFactory
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private val logger = LoggerFactory.getLogger(WorkflowHandleImpl::class.java)
@@ -198,6 +200,20 @@ interface WorkflowHandle : WorkflowHandleBase {
      * @return The workflow history.
      */
     suspend fun getHistory(): WorkflowHistory
+
+    /**
+     * Streams workflow history events as a cold [kotlinx.coroutines.flow.Flow].
+     *
+     * Pages through the existing history, emitting each event in order. With
+     * [waitNewEvent] = true, reaching the current end of history switches to
+     * server-side long polling: the flow keeps emitting as new events are appended
+     * and completes when the workflow reaches a terminal state. Parity with the
+     * Python SDK's `fetch_history_events(wait_new_event=...)`.
+     *
+     * @param waitNewEvent Whether to long-poll for events past the current end of history
+     * @return A cold flow of history events; collect with a timeout when using [waitNewEvent]
+     */
+    fun fetchHistoryEvents(waitNewEvent: Boolean = false): kotlinx.coroutines.flow.Flow<TemporalHistoryEvent>
 }
 
 /**
@@ -370,6 +386,20 @@ internal class WorkflowHandleImpl(
                 EventType.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT,
                 EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
             )
+
+        /**
+         * Poll interval for the [fetchHistoryEvents] fallback used against servers
+         * that don't support ALL-event long polls (e.g. the time-skipping test server).
+         */
+        private const val FALLBACK_HISTORY_POLL_INTERVAL_MS = 200L
+
+        /**
+         * Per-RPC window for [fetchHistoryEvents] follow long-polls. Kept short because
+         * some servers (Java time-skipping test server) hold ALL-event long polls until
+         * the workflow closes even when new events exist - each expiry triggers a plain
+         * catch-up fetch, bounding event delivery latency to roughly this window.
+         */
+        private const val FOLLOW_LONG_POLL_WINDOW_MS = 2000
     }
 
     private sealed class CloseEventResult {
@@ -830,4 +860,105 @@ internal class WorkflowHandleImpl(
             codec = codec,
         )
     }
+
+    override fun fetchHistoryEvents(waitNewEvent: Boolean): kotlinx.coroutines.flow.Flow<TemporalHistoryEvent> =
+        kotlinx.coroutines.flow.flow {
+            // Events are emitted at most once, in order, tracked by monotonic event ID
+            var lastEmittedEventId = 0L
+            var sawTerminalEvent = false
+
+            suspend fun emitNew(events: List<HistoryEvent>) {
+                for (event in events) {
+                    if (event.eventId > lastEmittedEventId) {
+                        emit(TemporalHistoryEvent.fromProto(event, codec))
+                        lastEmittedEventId = event.eventId
+                        if (event.eventType in CLOSE_EVENT_TYPES) {
+                            sawTerminalEvent = true
+                        }
+                    }
+                }
+            }
+
+            fun buildRequest(
+                waitNew: Boolean,
+                token: com.google.protobuf.ByteString,
+            ): GetWorkflowExecutionHistoryRequest =
+                GetWorkflowExecutionHistoryRequest
+                    .newBuilder()
+                    .setNamespace(serviceClient.namespace)
+                    .setExecution(
+                        WorkflowExecution
+                            .newBuilder()
+                            .setWorkflowId(workflowId)
+                            .also { if (runId != null) it.setRunId(runId) }
+                            .build(),
+                    ).setHistoryEventFilterType(HistoryEventFilterType.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+                    .setWaitNewEvent(waitNew)
+                    .setSkipArchival(true)
+                    .setNextPageToken(token)
+                    .build()
+
+            suspend fun plainCatchUp() {
+                var token = com.google.protobuf.ByteString.EMPTY
+                do {
+                    val response =
+                        try {
+                            serviceClient.getWorkflowExecutionHistory(buildRequest(waitNew = false, token = token))
+                        } catch (e: TemporalCoreException) {
+                            e.rethrowMapped(workflowId, runId)
+                        }
+                    emitNew(response.history.eventsList)
+                    token = response.nextPageToken
+                } while (!token.isEmpty)
+            }
+
+            // A single long-poll RPC bounded to a short window; null on window expiry.
+            // The window must be short: the Java time-skipping test server holds
+            // ALL-event long polls until the workflow CLOSES (ignoring new events), so
+            // expiry + plain catch-up is what delivers events promptly there. On real
+            // servers the poll returns as soon as events arrive, so the window only
+            // determines idle re-poll frequency.
+            suspend fun tryLongPoll(token: com.google.protobuf.ByteString): GetWorkflowExecutionHistoryResponse? =
+                try {
+                    serviceClient.getWorkflowExecutionHistory(
+                        buildRequest(waitNew = true, token = token),
+                        timeoutMillis = FOLLOW_LONG_POLL_WINDOW_MS,
+                    )
+                } catch (e: TemporalCoreException) {
+                    if (e.statusCode == GRPC_CANCELLED || e.statusCode == GRPC_DEADLINE_EXCEEDED) {
+                        null // poll window elapsed
+                    } else {
+                        e.rethrowMapped(workflowId, runId)
+                    }
+                }
+
+            // Phase 1: page through the existing history (works on every server)
+            plainCatchUp()
+            if (!waitNewEvent || sawTerminalEvent) {
+                return@flow
+            }
+
+            // Phase 2: follow new events. Long-poll for promptness, plain catch-up on
+            // window expiry for correctness (emitNew dedupes overlap by event ID).
+            var token = com.google.protobuf.ByteString.EMPTY
+            while (!sawTerminalEvent) {
+                currentCoroutineContext().ensureActive()
+                val response = tryLongPoll(token)
+                if (response == null) {
+                    // Window expired: pick up anything the long poll didn't deliver
+                    plainCatchUp()
+                    continue
+                }
+                emitNew(response.history.eventsList)
+                token = response.nextPageToken
+                if (token.isEmpty && !sawTerminalEvent) {
+                    // Stream ended without a terminal event (server without ALL-event
+                    // long-poll support): degrade to plain polling
+                    while (!sawTerminalEvent) {
+                        kotlinx.coroutines.delay(FALLBACK_HISTORY_POLL_INTERVAL_MS.milliseconds)
+                        plainCatchUp()
+                    }
+                }
+            }
+        }
 }

--- a/core/src/main/kotlin/com/surrealdev/temporal/serialization/SafePayloadCodec.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/serialization/SafePayloadCodec.kt
@@ -18,8 +18,13 @@ import kotlin.reflect.KType
  * @return Encoded payloads
  * @throws PayloadCodecException if encoding fails
  */
-internal suspend fun PayloadCodec.safeEncode(payloads: TemporalPayloads): EncodedTemporalPayloads =
-    lockWorkflowDispatcherIfPresent {
+internal suspend fun PayloadCodec.safeEncode(payloads: TemporalPayloads): EncodedTemporalPayloads {
+    // Fast path: the no-op codec never suspends or throws, so skip the dispatcher
+    // lock (which spins up a nested runBlocking event loop per call when invoked
+    // on the workflow dispatcher - a hot path for every activity/child schedule).
+    if (this === NoOpCodec) return NoOpCodec.encode(payloads)
+
+    return lockWorkflowDispatcherIfPresent {
         try {
             this.encode(payloads)
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -30,6 +35,7 @@ internal suspend fun PayloadCodec.safeEncode(payloads: TemporalPayloads): Encode
             throw PayloadCodecException("Codec encode failed: ${e.message}", e)
         }
     }
+}
 
 /**
  * Safe wrapper for [PayloadCodec.decode] that normalizes all exceptions to [PayloadCodecException].
@@ -41,8 +47,11 @@ internal suspend fun PayloadCodec.safeEncode(payloads: TemporalPayloads): Encode
  * @return Decoded payloads
  * @throws PayloadCodecException if decoding fails
  */
-internal suspend fun PayloadCodec.safeDecode(payloads: EncodedTemporalPayloads): TemporalPayloads =
-    lockWorkflowDispatcherIfPresent {
+internal suspend fun PayloadCodec.safeDecode(payloads: EncodedTemporalPayloads): TemporalPayloads {
+    // Fast path: see safeEncode
+    if (this === NoOpCodec) return NoOpCodec.decode(payloads)
+
+    return lockWorkflowDispatcherIfPresent {
         try {
             this.decode(payloads)
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -53,6 +62,7 @@ internal suspend fun PayloadCodec.safeDecode(payloads: EncodedTemporalPayloads):
             throw PayloadCodecException("Codec decode failed: ${e.message}", e)
         }
     }
+}
 
 /**
  * Safe wrapper for [PayloadSerializer.serialize] that normalizes all exceptions to [PayloadSerializationException].

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/ActivityHandle.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/ActivityHandle.kt
@@ -67,7 +67,8 @@ interface ActivityHandle {
      * The behavior depends on the [ActivityCancellationType] set in options:
      * - TRY_CANCEL: Sends cancel request, Core SDK immediately resolves with cancelled status
      * - WAIT_CANCELLATION_COMPLETED: Sends cancel request, waits for acknowledgment
-     * - ABANDON: Does nothing (activity continues, result() returns immediately with cancellation)
+     * - ABANDON: Core SDK resolves with canceled status immediately and does not ask the
+     *   server to cancel - the activity keeps running server-side
      *
      * In all cases, this method returns immediately. The difference is when [resultPayload] returns.
      *

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/LocalActivityOptions.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/LocalActivityOptions.kt
@@ -30,6 +30,8 @@ import kotlin.time.Duration.Companion.minutes
  *                               in Core SDK. Defaults to 1 minute.
  * @property cancellationType How to handle cancellation of this local activity. Per proto comment, lang should
  *                           default to WAIT_CANCELLATION_COMPLETED for local activities.
+ * @property summary Single-line summary of this activity, shown in the Temporal UI.
+ *                   Sent as user metadata on the schedule command (serialized, not codec-encoded).
  */
 data class LocalActivityOptions(
     val startToCloseTimeout: Duration? = null,
@@ -39,6 +41,7 @@ data class LocalActivityOptions(
     val retryPolicy: RetryPolicy? = null,
     val localRetryThreshold: Duration = 1.minutes,
     val cancellationType: ActivityCancellationType = ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+    val summary: String? = null,
 ) {
     init {
         if (startToCloseTimeout == null && scheduleToCloseTimeout == null) {

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/WorkflowContext.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/WorkflowContext.kt
@@ -132,8 +132,12 @@ interface WorkflowContext :
      * This creates a durable timer that survives workflow replay.
      *
      * @param duration How long to sleep
+     * @param summary Optional single-line summary shown for this timer in the Temporal UI
      */
-    suspend fun sleep(duration: Duration)
+    suspend fun sleep(
+        duration: Duration,
+        summary: String? = null,
+    )
 
     /**
      * Suspends the workflow until the specified condition is met.
@@ -210,6 +214,25 @@ interface WorkflowContext :
      * @return `true` if workflow should use new behavior, `false` for legacy path
      */
     fun patched(patchId: String): Boolean
+
+    /**
+     * Marks a patch as deprecated - the final step of the patch lifecycle.
+     *
+     * Call this once all workflows that could take the OLD code path have completed,
+     * and the `patched(patchId)` conditional plus the old branch have been removed.
+     * It records a deprecated patch marker so histories written while the patch was
+     * live still replay correctly; once no such histories remain, this call can be
+     * removed entirely.
+     *
+     * ```kotlin
+     * // Step 1: if (patched("my-change")) { new() } else { old() }
+     * // Step 2: deprecatePatch("my-change"); new()
+     * // Step 3: new()
+     * ```
+     *
+     * @param patchId The patch identifier previously used with [patched]
+     */
+    fun deprecatePatch(patchId: String)
 
     /**
      * Returns the current history length (number of events).
@@ -620,13 +643,19 @@ data class ActivityOptions(
     /** Headers for context propagation, tracing, and auth. Payloads allow typed serialization. */
     val headers: Map<String, TemporalPayload>? = null,
     /**
-     * Priority for this activity task. Higher priority tasks are scheduled first.
-     * Note: Server support for priority is not yet available. This is a placeholder.
-     * Value range: 0 (lowest) to 100 (highest), default is 0.
+     * Priority key for this activity task. Temporal semantics: LOWER keys are scheduled
+     * first (1 is the highest priority). 0 means unset - the server applies its default
+     * (middle) priority. The default server configuration supports keys 1-5.
+     * Ignored by servers without priority support.
      */
     val priority: Int = 0,
     /** If true, worker won't attempt eager execution even if slots available. */
     val disableEagerExecution: Boolean = false,
+    /**
+     * Single-line summary of this activity, shown in the Temporal UI.
+     * Sent as user metadata on the schedule command (serialized, not codec-encoded).
+     */
+    val summary: String? = null,
 ) {
     init {
         if (startToCloseTimeout == null && scheduleToCloseTimeout == null) {
@@ -662,6 +691,24 @@ data class ChildWorkflowOptions(
     val searchAttributes: TypedSearchAttributes? = null,
     /** Policy for reusing a workflow ID that was previously used. Null lets the server pick its default. */
     val workflowIdReusePolicy: WorkflowIdReusePolicy? = null,
+    /** Maximum time for a single workflow task of the child workflow. Null uses the server default. */
+    val workflowTaskTimeout: Duration? = null,
+    /** Cron schedule for the child workflow (e.g. "0 12 * * *"). Empty/null means not a cron workflow. */
+    val cronSchedule: String? = null,
+    /** Memo key-value pairs attached to the child workflow. */
+    val memo: Map<String, TemporalPayload>? = null,
+    /** Whether the child should run on a worker with a compatible build id. */
+    val versioningIntent: VersioningIntent = VersioningIntent.UNSPECIFIED,
+    /**
+     * Priority key for the child workflow. Temporal semantics: LOWER keys are scheduled
+     * first (1 is the highest priority), 0 means unset - the server applies its default.
+     */
+    val priority: Int = 0,
+    /**
+     * Single-line summary of this child workflow, shown in the Temporal UI.
+     * Sent as user metadata on the start command (serialized, not codec-encoded).
+     */
+    val summary: String? = null,
 )
 
 /**
@@ -805,15 +852,13 @@ data class ContinueAsNewOptions(
     val workflowTaskTimeout: Duration? = null,
     /**
      * Memo for the new execution.
-     * - null: inherit current memo
-     * - empty map: clear memo
+     * - null or empty map: inherit current memo
      * - non-empty map: use specified memo
      */
     val memo: Map<String, TemporalPayload>? = null,
     /**
      * Search attributes for the new execution.
-     * - null: inherit current search attributes
-     * - empty map: clear search attributes
+     * - null or empty map: inherit current search attributes
      * - non-empty map: use specified search attributes
      */
     val searchAttributes: Map<String, TemporalPayload>? = null,

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ChildWorkflowHandleImpl.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ChildWorkflowHandleImpl.kt
@@ -69,18 +69,18 @@ internal class ChildWorkflowHandleImpl(
         get() = _firstExecutionRunId
 
     override suspend fun awaitStart(): String {
-        val runId = startDeferred.await()
+        val runId = awaitCancellingChild(startDeferred)
         _firstExecutionRunId = runId
         return runId
     }
 
     override suspend fun resultPayload(): TemporalPayload? {
         // Wait for start resolution first
-        val runId = startDeferred.await()
+        val runId = awaitCancellingChild(startDeferred)
         _firstExecutionRunId = runId
 
         // Wait for execution result
-        val result = executionDeferred.await()
+        val result = awaitCancellingChild(executionDeferred)
 
         return when {
             result.hasCompleted() -> {
@@ -118,18 +118,44 @@ internal class ChildWorkflowHandleImpl(
     }
 
     override fun cancel(reason: String) {
-        // Build cancel command
+        sendCancelCommand(reason)
+    }
+
+    private fun sendCancelCommand(reason: String) {
         val command =
             WorkflowCommands.WorkflowCommand
                 .newBuilder()
                 .setCancelChildWorkflowExecution(
                     WorkflowCommands.CancelChildWorkflowExecution
                         .newBuilder()
-                        .setChildWorkflowSeq(seq),
+                        .setChildWorkflowSeq(seq)
+                        .setReason(reason),
                 ).build()
 
         state.addCommand(command)
     }
+
+    /**
+     * Awaits a resolution deferred, cancelling the child workflow if the awaiting
+     * coroutine is cancelled first (e.g. `withTimeout { handle.result() }` or an
+     * enclosing scope being cancelled). Mirrors the Python SDK, where cancelling the
+     * handle task sends cancel_child_workflow_execution - including before the child
+     * has started (core reconciles pending-start cancels).
+     *
+     * No command is emitted during workflow teardown (terminal completion/eviction) or
+     * once the child has already resolved.
+     */
+    private suspend fun <T> awaitCancellingChild(deferred: CompletableDeferred<T>): T =
+        try {
+            deferred.await()
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            if (!state.workflowCompleted && state.getChildWorkflow(seq) != null) {
+                // Propagate the workflow's cancel reason when the cancellation came from
+                // a workflow-level cancel (Python parity)
+                sendCancelCommand(state.cancelReason ?: "Awaiting coroutine was cancelled")
+            }
+            throw e
+        }
 
     @InternalTemporalApi
     override suspend fun signalWithPayloads(
@@ -184,7 +210,7 @@ internal class ChildWorkflowHandleImpl(
 
         // Register and await resolution
         val deferred = state.registerExternalSignal(signalSeq)
-        val failure = deferred.await()
+        val failure = awaitExternalSignalResolution(state, signalSeq, deferred)
 
         // If there was a failure, throw an exception
         if (failure != null) {

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ExternalWorkflowHandleImpl.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ExternalWorkflowHandleImpl.kt
@@ -103,7 +103,7 @@ internal class ExternalWorkflowHandleImpl(
 
         // Register and await resolution
         val deferred = state.registerExternalSignal(signalSeq)
-        val failure = deferred.await()
+        val failure = awaitExternalSignalResolution(state, signalSeq, deferred)
 
         // If there was a failure, throw an exception
         if (failure != null) {
@@ -160,3 +160,30 @@ internal class ExternalWorkflowHandleImpl(
         }
     }
 }
+
+/**
+ * Awaits an external-signal resolution, rescinding the not-yet-sent signal with a
+ * CancelSignalWorkflow command if the awaiting coroutine is cancelled first
+ * (Python parity). No command is emitted during workflow teardown or once resolved.
+ */
+internal suspend fun awaitExternalSignalResolution(
+    state: WorkflowState,
+    signalSeq: Int,
+    deferred: kotlinx.coroutines.CompletableDeferred<io.temporal.api.failure.v1.Failure?>,
+): io.temporal.api.failure.v1.Failure? =
+    try {
+        deferred.await()
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        if (!state.workflowCompleted && state.removeExternalSignal(signalSeq)) {
+            state.addCommand(
+                WorkflowCommands.WorkflowCommand
+                    .newBuilder()
+                    .setCancelSignalWorkflow(
+                        WorkflowCommands.CancelSignalWorkflow
+                            .newBuilder()
+                            .setSeq(signalSeq),
+                    ).build(),
+            )
+        }
+        throw e
+    }

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/LocalActivityHandleImpl.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/LocalActivityHandleImpl.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.CompletableDeferred
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.logging.Logger
 import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
 /**
@@ -52,6 +51,8 @@ internal class LocalActivityHandleImpl(
     private val options: LocalActivityOptions,
     private val cancellationType: ActivityCancellationType,
     private val arguments: List<Payload>,
+    private val headers: Map<String, Payload> = emptyMap(),
+    private val userMetadata: io.temporal.api.sdk.v1.UserMetadata? = null,
 ) : LocalActivityHandle {
     companion object {
         private val logger = Logger.getLogger(LocalActivityHandleImpl::class.java.name)
@@ -128,23 +129,9 @@ internal class LocalActivityHandleImpl(
                 "cancellationType=$cancellationType, reason=\"$reason\"",
         )
 
-        // Handle different cancellation types
-        when (cancellationType) {
-            ActivityCancellationType.TRY_CANCEL -> {
-                // Send cancel command - Core SDK resolves immediately
-                sendCancelCommand()
-            }
-
-            ActivityCancellationType.WAIT_CANCELLATION_COMPLETED -> {
-                // Send cancel command - Core SDK waits for acknowledgment
-                sendCancelCommand()
-            }
-
-            ActivityCancellationType.ABANDON -> {
-                // Don't send cancel command - just mark as cancelled locally
-                logger.info("Abandoning local activity without sending cancel command: id=$activityId, seq=$currentSeq")
-            }
-        }
+        // Always send the cancel command - Core SDK owns the cancellation-type semantics
+        // (TRY_CANCEL / WAIT_CANCELLATION_COMPLETED / ABANDON all resolve through core).
+        sendCancelCommand()
     }
 
     /**
@@ -237,6 +224,11 @@ internal class LocalActivityHandleImpl(
                 .setAttempt(backoff.attempt.toInt())
                 .addAllArguments(arguments)
 
+        // Re-apply headers from the original schedule
+        if (headers.isNotEmpty()) {
+            builder.putAllHeaders(headers)
+        }
+
         // Set original schedule time (required for correct timeout calculations)
         backoff.originalScheduleTime?.let { builder.setOriginalScheduleTime(it) }
 
@@ -262,10 +254,15 @@ internal class LocalActivityHandleImpl(
         // Set cancellation type
         builder.setCancellationType(cancellationType.toLocalActivityProto())
 
-        return WorkflowCommands.WorkflowCommand
-            .newBuilder()
-            .setScheduleLocalActivity(builder)
-            .build()
+        val commandBuilder =
+            WorkflowCommands.WorkflowCommand
+                .newBuilder()
+                .setScheduleLocalActivity(builder)
+
+        // Re-apply the summary user metadata from the original schedule
+        userMetadata?.let { commandBuilder.setUserMetadata(it) }
+
+        return commandBuilder.build()
     }
 
     /**
@@ -329,18 +326,6 @@ internal class DoBackoffException(
     val backoffDuration: Duration,
     val originalScheduleTime: Timestamp?,
 ) : Exception("Local activity backoff: attempt=$attempt, duration=$backoffDuration")
-
-/**
- * Converts a Kotlin Duration to a protobuf Duration.
- */
-private fun Duration.toProtoDuration(): com.google.protobuf.Duration {
-    val javaDuration = this.toJavaDuration()
-    return com.google.protobuf.Duration
-        .newBuilder()
-        .setSeconds(javaDuration.seconds)
-        .setNanos(javaDuration.nano)
-        .build()
-}
 
 /**
  * Converts a protobuf Duration to a Kotlin Duration.

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ProtoConversions.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/ProtoConversions.kt
@@ -1,0 +1,37 @@
+package com.surrealdev.temporal.workflow.internal
+
+import com.surrealdev.temporal.common.toProto
+import com.surrealdev.temporal.serialization.PayloadSerializer
+import kotlin.reflect.typeOf
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+/**
+ * Converts a Kotlin [Duration] to a protobuf Duration.
+ *
+ * Shared by all command builders (timers, activities, child workflows,
+ * continue-as-new).
+ */
+internal fun Duration.toProtoDuration(): com.google.protobuf.Duration {
+    val javaDuration = this.toJavaDuration()
+    return com.google.protobuf.Duration
+        .newBuilder()
+        .setSeconds(javaDuration.seconds)
+        .setNanos(javaDuration.nano)
+        .build()
+}
+
+/**
+ * Builds the per-command user metadata carrying a UI-facing summary.
+ *
+ * The summary is serialized with the payload serializer but intentionally NOT
+ * codec-encoded - it is UI-facing metadata, matching other SDKs.
+ */
+internal fun buildUserMetadata(
+    serializer: PayloadSerializer,
+    summary: String,
+): io.temporal.api.sdk.v1.UserMetadata =
+    io.temporal.api.sdk.v1.UserMetadata
+        .newBuilder()
+        .setSummary(serializer.serialize(typeOf<String>(), summary).toProto())
+        .build()

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/RemoteActivityHandleImpl.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/RemoteActivityHandleImpl.kt
@@ -92,26 +92,11 @@ internal class RemoteActivityHandleImpl(
                 "cancellationType=$cancellationType, reason=\"$reason\"",
         )
 
-        // Handle different cancellation types
-        when (cancellationType) {
-            ActivityCancellationType.TRY_CANCEL -> {
-                // Send cancel command - Core SDK resolves immediately
-                sendCancelCommand()
-            }
-
-            ActivityCancellationType.WAIT_CANCELLATION_COMPLETED -> {
-                // Send cancel command - Core SDK waits for ActivityTaskCanceled event
-                // The difference from TRY_CANCEL is in Core SDK behavior, not our behavior
-                sendCancelCommand()
-            }
-
-            ActivityCancellationType.ABANDON -> {
-                // Don't send cancel command - just mark as cancelled locally
-                // Activity continues running but workflow doesn't wait for it
-                logger.info("Abandoning activity without sending cancel command: id=$activityId, seq=$seq")
-                // Note: We don't send a command, cancellation is local-only
-            }
-        }
+        // Always send the cancel command - Core SDK owns the cancellation-type semantics:
+        // - TRY_CANCEL: resolves immediately, sends a cancel request to the server
+        // - WAIT_CANCELLATION_COMPLETED: resolves after the ActivityTaskCanceled event
+        // - ABANDON: resolves immediately without a server round trip; the activity keeps running
+        sendCancelCommand()
     }
 
     /**

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowContextImpl.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowContextImpl.kt
@@ -55,7 +55,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KType
 import kotlin.time.Duration
 import kotlin.time.Instant
-import kotlin.time.toJavaDuration
 
 /**
  * Implementation of [WorkflowContext] for workflow execution.
@@ -333,9 +332,9 @@ internal class WorkflowContextImpl(
             }
         }
 
-        // 6. Priority validation
-        require(options.priority in 0..100) {
-            "priority must be in range 0-100, got: ${options.priority}"
+        // 6. Priority validation - 0 means unset (server default); lower keys run first
+        require(options.priority >= 0) {
+            "priority must be >= 0 (0 = unset/server default), got: ${options.priority}"
         }
 
         // 7. RetryPolicy validation
@@ -401,18 +400,23 @@ internal class WorkflowContextImpl(
         scheduleActivityBuilder.setCancellationType(options.cancellationType.toProto())
         scheduleActivityBuilder.setVersioningIntent(options.versioningIntent.toProto())
 
-        // Set headers from options (may be modified by interceptors via input.options)
-        if (!options.headers.isNullOrEmpty()) {
-            scheduleActivityBuilder.putAllHeaders(options.headers.mapValues { (_, v) -> v.toProto() })
+        // Merge headers: options.headers first, then interceptor-added headers
+        // (interceptor entries win on key collision)
+        val headers =
+            buildMap {
+                options.headers?.let { putAll(it) }
+                putAll(input.headers)
+            }
+        if (headers.isNotEmpty()) {
+            scheduleActivityBuilder.putAllHeaders(headers.mapValues { (_, v) -> v.toProto() })
         }
 
         // Set eager execution flag
         scheduleActivityBuilder.setDoNotEagerlyExecute(options.disableEagerExecution)
 
-        // Set priority field
-        // Note: Priority support was added in Temporal Server 1.22.0 (May 2023).
-        // On older servers, this field is ignored (no error). Priority key is 1-5 by default,
-        // but our API uses 0-100 for future extensibility. The proto supports any int32 value.
+        // Set priority field - passthrough of the priority key. Temporal semantics:
+        // lower key = higher priority, 0 = unset (server default). Ignored by servers
+        // without priority support.
         scheduleActivityBuilder.setPriority(
             io.temporal.api.common.v1.Priority
                 .newBuilder()
@@ -420,13 +424,16 @@ internal class WorkflowContextImpl(
                 .build(),
         )
 
-        val command =
+        val commandBuilder =
             WorkflowCommands.WorkflowCommand
                 .newBuilder()
                 .setScheduleActivity(scheduleActivityBuilder)
-                .build()
 
-        state.addCommand(command)
+        options.summary?.let { summary ->
+            commandBuilder.setUserMetadata(buildUserMetadata(summary))
+        }
+
+        state.addCommand(commandBuilder.build())
 
         logger.info(
             "Scheduled activity: type=$activityType, id=$activityId, seq=$seq, " +
@@ -512,6 +519,9 @@ internal class WorkflowContextImpl(
 
         logger.fine("Building ScheduleLocalActivity command: type=$activityType, id=$activityId")
 
+        // Encode once - the same payloads are reused for backoff reschedules via the handle
+        val encodedArgs = codec.safeEncode(args).proto.payloadsList
+
         val scheduleLocalActivityBuilder =
             WorkflowCommands.ScheduleLocalActivity
                 .newBuilder()
@@ -519,7 +529,7 @@ internal class WorkflowContextImpl(
                 .setActivityId(activityId)
                 .setActivityType(activityType)
                 .setAttempt(1) // Initial attempt is 1
-                .addAllArguments(codec.safeEncode(args).proto.payloadsList)
+                .addAllArguments(encodedArgs)
 
         // Set optional timeouts
         options.startToCloseTimeout?.let {
@@ -544,17 +554,21 @@ internal class WorkflowContextImpl(
         scheduleLocalActivityBuilder.setCancellationType(options.cancellationType.toProto())
 
         // Set headers from interceptor input (may be modified by interceptors)
-        if (input.headers.isNotEmpty()) {
-            scheduleLocalActivityBuilder.putAllHeaders(input.headers.mapValues { (_, v) -> v.toProto() })
+        val protoHeaders = input.headers.mapValues { (_, v) -> v.toProto() }
+        if (protoHeaders.isNotEmpty()) {
+            scheduleLocalActivityBuilder.putAllHeaders(protoHeaders)
         }
 
-        val command =
+        val userMetadata = options.summary?.let { buildUserMetadata(it) }
+
+        val commandBuilder =
             WorkflowCommands.WorkflowCommand
                 .newBuilder()
                 .setScheduleLocalActivity(scheduleLocalActivityBuilder)
-                .build()
 
-        state.addCommand(command)
+        userMetadata?.let { commandBuilder.setUserMetadata(it) }
+
+        state.addCommand(commandBuilder.build())
 
         logger.info(
             "Scheduled local activity: type=$activityType, id=$activityId, seq=$seq",
@@ -572,7 +586,9 @@ internal class WorkflowContextImpl(
                 serializer = serializer,
                 options = options,
                 cancellationType = options.cancellationType,
-                arguments = codec.safeEncode(args).proto.payloadsList,
+                arguments = encodedArgs,
+                headers = protoHeaders,
+                userMetadata = userMetadata,
             )
 
         state.registerLocalActivity(seq, handle)
@@ -584,7 +600,17 @@ internal class WorkflowContextImpl(
         return handle
     }
 
-    override suspend fun sleep(duration: Duration) {
+    /**
+     * Builds the per-command user metadata carrying a UI-facing summary.
+     * See [buildUserMetadata] in ProtoConversions.kt.
+     */
+    private fun buildUserMetadata(summary: String): io.temporal.api.sdk.v1.UserMetadata =
+        buildUserMetadata(serializer, summary)
+
+    override suspend fun sleep(
+        duration: Duration,
+        summary: String?,
+    ) {
         ensureOnWorkflowDispatcher("sleep")
         if (duration.isNegative() || duration == Duration.ZERO) {
             // No-op for zero or negative duration
@@ -592,18 +618,21 @@ internal class WorkflowContextImpl(
         }
 
         // Execute through the interceptor chain
-        val interceptorInput = SleepInput(duration = duration)
+        val interceptorInput = SleepInput(duration = duration, summary = summary)
         val chain = hookRegistry.chain(Sleep)
         chain.execute(interceptorInput) { input ->
-            sleepInternal(input.duration)
+            sleepInternal(input.duration, input.summary)
         }
     }
 
-    private suspend fun sleepInternal(duration: Duration) {
+    private suspend fun sleepInternal(
+        duration: Duration,
+        summary: String?,
+    ) {
         val seq = state.nextSeq()
 
         // Build the StartTimer command using Java builder API
-        val command =
+        val commandBuilder =
             WorkflowCommands.WorkflowCommand
                 .newBuilder()
                 .setStartTimer(
@@ -611,13 +640,33 @@ internal class WorkflowContextImpl(
                         .newBuilder()
                         .setSeq(seq)
                         .setStartToFireTimeout(duration.toProtoDuration()),
-                ).build()
+                )
 
-        state.addCommand(command)
+        summary?.let { commandBuilder.setUserMetadata(buildUserMetadata(it)) }
+
+        state.addCommand(commandBuilder.build())
 
         // Register pending timer and await
         val deferred = state.registerTimer(seq)
-        deferred.await()
+        try {
+            deferred.await()
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // The sleeping coroutine was cancelled: tell core to cancel the server-side
+            // timer, unless it already fired or the workflow is tearing down (terminal
+            // completion / eviction must not emit commands - replay compatibility).
+            if (!state.workflowCompleted && state.removeTimer(seq)) {
+                state.addCommand(
+                    WorkflowCommands.WorkflowCommand
+                        .newBuilder()
+                        .setCancelTimer(
+                            WorkflowCommands.CancelTimer
+                                .newBuilder()
+                                .setSeq(seq),
+                        ).build(),
+                )
+            }
+            throw e
+        }
     }
 
     override suspend fun awaitCondition(condition: () -> Boolean) {
@@ -660,9 +709,17 @@ internal class WorkflowContextImpl(
         } else {
             try {
                 // Use coroutine withTimeout - it uses delay() which is intercepted
-                // by WorkflowTimerScheduler to create durable timers
-                kotlinx.coroutines.withTimeout(timeout) {
-                    deferred.await()
+                // by WorkflowTimerScheduler to create durable timers.
+                // withTimeout schedules its timeout timer synchronously in this call
+                // stack, so the summary handoff below reaches exactly that timer.
+                timeoutSummary?.let { state.pendingTimerSummary = it }
+                try {
+                    kotlinx.coroutines.withTimeout(timeout) {
+                        deferred.await()
+                    }
+                } finally {
+                    // Defensive: never leak a stale summary to an unrelated timer
+                    state.pendingTimerSummary = null
                 }
             } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
                 // Clean up the condition from registry
@@ -678,10 +735,8 @@ internal class WorkflowContextImpl(
         }
     }
 
-    override fun now(): Instant =
-        Instant.fromEpochMilliseconds(
-            state.currentTime.toEpochMilliseconds(),
-        )
+    // Full activation-timestamp precision (nanoseconds), matching Python's time_ns
+    override fun now(): Instant = state.currentTime
 
     override fun randomUuid(): String = deterministicRandom.randomUuid()
 
@@ -701,6 +756,15 @@ internal class WorkflowContextImpl(
         }
 
         return usePatch
+    }
+
+    override fun deprecatePatch(patchId: String) {
+        // Idempotent within an execution: record the marker only once
+        if (state.getPatchMemo(patchId) != null) {
+            return
+        }
+        state.setPatchMemo(patchId, true)
+        state.addCommand(createSetPatchMarkerCommand(patchId, deprecated = true))
     }
 
     override suspend fun startChildWorkflowWithPayloads(
@@ -761,6 +825,30 @@ internal class WorkflowContextImpl(
             commandBuilder.setWorkflowIdReusePolicy(it.toProto())
         }
 
+        // Set workflow task timeout if provided
+        options.workflowTaskTimeout?.let {
+            commandBuilder.setWorkflowTaskTimeout(it.toProtoDuration())
+        }
+
+        // Set cron schedule if provided
+        options.cronSchedule?.takeIf { it.isNotBlank() }?.let {
+            commandBuilder.setCronSchedule(it)
+        }
+
+        // Set memo if provided
+        options.memo?.takeIf { it.isNotEmpty() }?.let { memo ->
+            commandBuilder.putAllMemo(memo.mapValues { (_, v) -> v.toProto() })
+        }
+
+        // Versioning intent and priority (see ActivityOptions.priority for key semantics)
+        commandBuilder.setVersioningIntent(options.versioningIntent.toProto())
+        commandBuilder.setPriority(
+            io.temporal.api.common.v1.Priority
+                .newBuilder()
+                .setPriorityKey(options.priority)
+                .build(),
+        )
+
         // Set search attributes if provided
         options.searchAttributes?.let { attrs ->
             if (attrs.isNotEmpty()) {
@@ -776,13 +864,16 @@ internal class WorkflowContextImpl(
             commandBuilder.putAllHeaders(input.headers.mapValues { (_, v) -> v.toProto() })
         }
 
-        val command =
+        val childCommandBuilder =
             WorkflowCommands.WorkflowCommand
                 .newBuilder()
                 .setStartChildWorkflowExecution(commandBuilder)
-                .build()
 
-        state.addCommand(command)
+        options.summary?.let { summary ->
+            childCommandBuilder.setUserMetadata(buildUserMetadata(summary))
+        }
+
+        state.addCommand(childCommandBuilder.build())
 
         // Create and register the handle
         val handle =
@@ -832,12 +923,22 @@ internal class WorkflowContextImpl(
             runtimeSignalHandlers.remove(name)
         } else {
             runtimeSignalHandlers[name] = handler
-            // Immediately launch tasks for any buffered signals
-            // These tasks are queued to the WorkflowCoroutineDispatcher and will
-            // execute during the next processAllWork() call, matching Python SDK behavior
+            // Immediately launch tasks for any buffered signals.
+            // Replayed buffered signals must behave exactly like live signal deliveries:
+            // run on the handler job (surviving workflow completion) and swallow-and-log
+            // exceptions instead of failing the workflow. Matches Python, which replays
+            // buffered signals through the same processing path as live ones.
             bufferedSignals.remove(name)?.let { signals ->
                 for (payloads in signals) {
-                    launch { handler(payloads) }
+                    launchHandler {
+                        try {
+                            handler(payloads)
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            logger.warning("Buffered signal handler threw exception: ${e.message}")
+                        }
+                    }
                 }
             }
         }
@@ -850,12 +951,19 @@ internal class WorkflowContextImpl(
     ) {
         runtimeDynamicSignalHandler = handler
         if (handler != null) {
-            // Immediately launch tasks for all buffered signals
-            // These tasks are queued to the WorkflowCoroutineDispatcher and will
-            // execute during the next processAllWork() call, matching Python SDK behavior
+            // Immediately launch tasks for all buffered signals - same semantics as
+            // live signal deliveries (handler job + swallow-and-log), see above
             for ((signalName, signals) in bufferedSignals) {
                 for (payloads in signals) {
-                    launch { handler(signalName, payloads) }
+                    launchHandler {
+                        try {
+                            handler(signalName, payloads)
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            logger.warning("Buffered dynamic signal handler threw exception: ${e.message}")
+                        }
+                    }
                 }
             }
             bufferedSignals.clear()
@@ -984,18 +1092,6 @@ internal data class DynamicUpdateHandlerEntry(
     val handler: suspend (updateName: String, args: TemporalPayloads) -> TemporalPayload,
     val validator: ((updateName: String, args: TemporalPayloads) -> Unit)?,
 )
-
-/**
- * Converts a Kotlin [Duration] to a protobuf [com.google.protobuf.Duration].
- */
-private fun Duration.toProtoDuration(): com.google.protobuf.Duration {
-    val javaDuration = this.toJavaDuration()
-    return com.google.protobuf.Duration
-        .newBuilder()
-        .setSeconds(javaDuration.seconds)
-        .setNanos(javaDuration.nano)
-        .build()
-}
 
 /**
  * Converts our domain [ParentClosePolicy] to the protobuf enum.

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowDispatcher.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowDispatcher.kt
@@ -156,8 +156,20 @@ internal class WorkflowDispatcher(
         if (isEviction(activation)) {
             val entry = executors.remove(runId)
             entry?.let {
-                // Cancel the executor job
-                it.executor.terminateWorkflowExecutionJob()
+                // Run teardown ON the workflow's own virtual thread (the executor's
+                // activate() handles RemoveFromCache via handleEviction). Cancellation
+                // handlers and `finally` blocks in workflow code must observe the same
+                // thread as normal execution - draining them on the poller thread
+                // violates the single-thread invariant (ThreadLocals, MDC, plugins).
+                try {
+                    it.mutex.withLock {
+                        it.virtualThread.dispatch(activation)
+                    }
+                } catch (e: Exception) {
+                    // Teardown failures (including deadlocks) must not fail the poll -
+                    // the interrupting termination job below is the backstop
+                    logger.warn("Eviction teardown failed for run_id={}: {}", runId, e.message)
+                }
                 // Launch async termination - doesn't block the poll
                 launchTerminationJob(
                     virtualThread = it.virtualThread,

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutor.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutor.kt
@@ -76,6 +76,14 @@ internal class WorkflowExecutor(
      */
     internal val pendingQueryResults = mutableListOf<WorkflowCommands.WorkflowCommand>()
 
+    /**
+     * A non-failure exception thrown by a handler (e.g. an accepted update) that must
+     * fail this workflow TASK (retryable) rather than resolve the handler's protocol
+     * message. Checked once per activation before building the completion. Mirrors
+     * Python's `_current_activation_error`.
+     */
+    internal var pendingActivationFailure: Throwable? = null
+
     /** Builds MDC map with workflow identifiers for the coroutine context hook. */
     private fun buildMdcMap(): Map<String, String> =
         buildMap {
@@ -192,6 +200,17 @@ internal class WorkflowExecutor(
             logger.debug("Exception during eviction cleanup: {}", e.message)
         }
 
+        // Drain check: after cancelling everything and draining, remaining queued work
+        // means coroutines that couldn't be torn down cleanly (e.g. escaped dispatchers
+        // or never-completing continuations) - a leak candidate worth surfacing.
+        if (workflowDispatcher.hasPendingWork()) {
+            logger.warn(
+                "[TKT1109] Workflow teardown left undrained tasks on the dispatcher. " +
+                    "run_id={} - possible leaked coroutine.",
+                runId,
+            )
+        }
+
         workflowDispatcher.clear()
 
         workflowExecutionJob = null
@@ -215,12 +234,15 @@ internal class WorkflowExecutor(
     suspend fun activate(activation: WorkflowActivation): WorkflowDispatchResult =
         withContext(CoroutineName("WorkflowExecutor-activate")) {
             try {
-                logger.debug(
-                    "Processing activation: jobs={}, replaying={}, historyLength={}",
-                    activation.jobsList.map { jobTypeName(it) },
-                    activation.isReplaying,
-                    activation.historyLength,
-                )
+                if (logger.isDebugEnabled) {
+                    // Guarded: building the per-job name list allocates on every activation
+                    logger.debug(
+                        "Processing activation: jobs={}, replaying={}, historyLength={}",
+                        activation.jobsList.map { jobTypeName(it) },
+                        activation.isReplaying,
+                        activation.historyLength,
+                    )
+                }
 
                 // Update state from activation metadata
                 state.updateFromActivation(
@@ -240,19 +262,39 @@ internal class WorkflowExecutor(
                 }
 
                 // Separate jobs into ordered stages following Python SDK pattern for deterministic replay:
-                // Stage 0: Initialization (if present)
-                // Stage 1: Patches (for workflow versioning - not yet implemented, placeholder for future)
+                // Stage 0: Patches (workflow versioning - must precede everything else)
+                // Stage 1: Initialization (if present)
                 // Stage 2: Signals + Updates (state mutations from external events)
                 // Stage 3: Non-queries (resolutions, cancellation, random seed, etc.)
                 // Stage 4: Queries (read-only operations)
                 // Note: RemoveFromCache (eviction) is handled as an early exit before stage processing
-                val initJob = activation.jobsList.find { it.hasInitializeWorkflow() }
-                val patchJobs = activation.jobsList.filter { isPatchJob(it) }
-                val signalAndUpdateJobs = activation.jobsList.filter { isSignalOrUpdateJob(it) }
-                val nonQueryJobs = activation.jobsList.filter { isNonQueryJob(it) }
-                val queryJobs = activation.jobsList.filter { it.hasQueryWorkflow() }
+                // Single pass over the job list into stage buckets (Python builds
+                // job_sets the same way)
+                var initJob: WorkflowActivationJob? = null
+                val patchJobs = mutableListOf<WorkflowActivationJob>()
+                val signalAndUpdateJobs = mutableListOf<WorkflowActivationJob>()
+                val nonQueryJobs = mutableListOf<WorkflowActivationJob>()
+                val queryJobs = mutableListOf<WorkflowActivationJob>()
+                for (job in activation.jobsList) {
+                    when {
+                        job.hasInitializeWorkflow() -> initJob = job
+                        isPatchJob(job) -> patchJobs.add(job)
+                        isSignalOrUpdateJob(job) -> signalAndUpdateJobs.add(job)
+                        job.hasQueryWorkflow() -> queryJobs.add(job)
+                        isNonQueryJob(job) -> nonQueryJobs.add(job)
+                    }
+                }
 
-                // Stage 0: Process initialization if present
+                // Stage 0: Process patches BEFORE anything runs workflow code. On replay,
+                // core bundles NotifyHasPatch with InitializeWorkflow in one activation; if
+                // workflow code calls patched() before its first suspension, the notification
+                // must already be recorded or the replay diverges from the original run
+                // (nondeterminism). Matches the Python SDK's job set ordering.
+                for (job in patchJobs) {
+                    processJob(job)
+                }
+
+                // Stage 1: Process initialization if present
                 // This sets pluginCoroutineContext (MDC + OTel + any plugin elements)
                 if (initJob != null) {
                     processJob(initJob)
@@ -269,14 +311,6 @@ internal class WorkflowExecutor(
                         ?: kotlin.coroutines.EmptyCoroutineContext
 
                 withContext(pluginCtx) pluginScope@{
-                    // Stage 1: Process patches
-                    for (job in patchJobs) {
-                        processJob(job)
-                    }
-                    if (patchJobs.isNotEmpty()) {
-                        runOnce(checkConditions = false)
-                    }
-
                     // Stage 2: Process signals and updates
                     for (job in signalAndUpdateJobs) {
                         processJob(job)
@@ -291,6 +325,21 @@ internal class WorkflowExecutor(
                     }
                     if (nonQueryJobs.isNotEmpty()) {
                         runOnce(checkConditions = true)
+                    }
+
+                    // A handler recorded a non-failure exception (e.g. an accepted update
+                    // handler bug): fail this workflow task so it can be retried.
+                    pendingActivationFailure?.let { err ->
+                        pendingActivationFailure = null
+                        logger.warn(
+                            "Workflow task failed by handler exception (will be retried): {}",
+                            err.message,
+                            err,
+                        )
+                        return@pluginScope WorkflowDispatchResult(
+                            completion = buildFailureCompletion(err),
+                            fatalError = if (err.isFatalError()) err as Error else null,
+                        )
                     }
 
                     // Check for workflow completion BEFORE processing queries.
@@ -507,7 +556,7 @@ internal class WorkflowExecutor(
             }
 
             job.hasCancelWorkflow() -> {
-                handleCancel()
+                handleCancel(job.cancelWorkflow.reason.takeIf { it.isNotBlank() })
             }
 
             job.hasRemoveFromCache() -> {
@@ -736,11 +785,13 @@ internal class WorkflowExecutor(
                 serializer.safeDeserialize(type, payload)
             }.toTypedArray()
 
-    private fun handleCancel() {
-        logger.debug("Workflow cancellation requested")
+    private fun handleCancel(reason: String?) {
+        logger.debug("Workflow cancellation requested: reason={}", reason)
 
-        // Set the cancellation flag immediately
+        // Set the cancellation flag and preserve the user-specified reason so it can
+        // be observed by workflow code and propagated (e.g. to child workflow cancels)
         state.cancelRequested = true
+        state.cancelReason = reason
 
         // Defer the actual cancellation to the next dispatcher cycle
         // This allows the workflow to receive the cancellation signal
@@ -748,7 +799,11 @@ internal class WorkflowExecutor(
         if (mainCoroutine != null) {
             workflowDispatcher.dispatch(kotlin.coroutines.EmptyCoroutineContext) {
                 // Cancel with our specific exception type
-                mainCoroutine?.cancel(WorkflowCancelledException())
+                mainCoroutine?.cancel(
+                    WorkflowCancelledException(
+                        reason?.let { "Workflow cancelled: $it" } ?: "Workflow cancelled",
+                    ),
+                )
             }
         }
     }
@@ -765,6 +820,10 @@ internal class WorkflowExecutor(
         terminateAllJobs()
 
         state.clear()
+
+        // Teardown cancellations may emit commands (e.g. CancelTimer from cancelled
+        // sleeps); an eviction completion must be empty, so discard them.
+        state.drainCommands()
     }
 
     private fun handleSignalExternalWorkflow(

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorCompletions.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorCompletions.kt
@@ -19,8 +19,6 @@ import io.temporal.api.common.v1.Payload
 import io.temporal.api.common.v1.SearchAttributes
 import io.temporal.api.failure.v1.Failure
 import kotlinx.coroutines.Deferred
-import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 import io.temporal.api.enums.v1.ContinueAsNewVersioningBehavior as ProtoContinueAsNewVersioningBehavior
 
 /*
@@ -117,14 +115,45 @@ internal suspend fun WorkflowExecutor.buildTerminalCompletion(
                 } else {
                     e
                 }
-            logger.info("Workflow failed with exception: {}", actualException.message, actualException)
-            WorkflowDispatchResult(
-                completion = buildWorkflowFailureCompletion(actualException),
-                fatalError = if (actualException.isFatalError()) actualException as Error else null,
-            )
+            if (actualException.isWorkflowFailureException()) {
+                // Failure-typed exceptions represent orderly business failures: fail the
+                // workflow permanently with a FailWorkflowExecution command.
+                logger.info("Workflow failed with exception: {}", actualException.message, actualException)
+                WorkflowDispatchResult(buildWorkflowFailureCompletion(actualException))
+            } else {
+                // Anything else is a bug (NPE, IllegalStateException, ...): fail the workflow
+                // TASK (retryable) so the workflow survives and can recover once the worker
+                // is fixed and redeployed. This matches the Python/Java/.NET SDKs.
+                logger.warn(
+                    "Workflow task failed with non-failure exception (will be retried): {}",
+                    actualException.message,
+                    actualException,
+                )
+                WorkflowDispatchResult(
+                    completion = buildFailureCompletion(actualException),
+                    fatalError = if (actualException.isFatalError()) actualException as Error else null,
+                )
+            }
         }
     }
 }
+
+/**
+ * Whether an exception thrown by workflow code should fail the WORKFLOW (permanent,
+ * FailWorkflowExecution) rather than the workflow TASK (retryable).
+ *
+ * Matches mainline SDK semantics (Python `workflow_is_failure_exception`, Java
+ * `TemporalFailure`): only Temporal failure-typed exceptions fail the workflow.
+ * Everything else is treated as a bug and fails the task so the workflow can recover
+ * after a worker fix.
+ */
+internal fun Throwable.isWorkflowFailureException(): Boolean =
+    this is com.surrealdev.temporal.common.exceptions.ApplicationFailure ||
+        this is com.surrealdev.temporal.common.exceptions.WorkflowActivityException ||
+        this is com.surrealdev.temporal.common.exceptions.ChildWorkflowException ||
+        this is com.surrealdev.temporal.common.exceptions.ExternalWorkflowException ||
+        this is com.surrealdev.temporal.common.exceptions.RemoteException ||
+        this is com.surrealdev.temporal.common.exceptions.WorkflowConditionTimeoutException
 
 /**
  * Unwraps a CancellationException to find the non-cancellation root cause.
@@ -297,7 +326,10 @@ internal suspend fun WorkflowExecutor.buildContinueAsNewCompletion(
     options.memo?.let { memo ->
         commandBuilder.putAllMemo(memo.mapValues { (_, v) -> v.toProto() })
     }
-    options.searchAttributes?.let { attrs ->
+    // An empty map must NOT set the field: proto semantics for continue-as-new say a
+    // present-but-empty SearchAttributes message overrides (clears), while an unset field
+    // inherits the current attributes. Python guards identically.
+    options.searchAttributes?.takeIf { it.isNotEmpty() }?.let { attrs ->
         commandBuilder.setSearchAttributes(
             SearchAttributes.newBuilder().putAllIndexedFields(attrs.mapValues { (_, v) -> v.toProto() }).build(),
         )
@@ -336,18 +368,6 @@ internal suspend fun WorkflowExecutor.buildContinueAsNewCompletion(
 // =============================================================================
 // Conversion Utilities for Continue-As-New
 // =============================================================================
-
-/**
- * Converts a Kotlin [Duration] to a protobuf [com.google.protobuf.Duration].
- */
-private fun Duration.toProtoDuration(): com.google.protobuf.Duration {
-    val javaDuration = this.toJavaDuration()
-    return com.google.protobuf.Duration
-        .newBuilder()
-        .setSeconds(javaDuration.seconds)
-        .setNanos(javaDuration.nano)
-        .build()
-}
 
 /**
  * Converts domain [VersioningIntent] to protobuf enum.

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorTimers.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorTimers.kt
@@ -3,7 +3,6 @@ package com.surrealdev.temporal.workflow.internal
 import coresdk.workflow_commands.WorkflowCommands
 import kotlinx.coroutines.CancellableContinuation
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.toJavaDuration
 
 /*
  * Extension functions for managing workflow timers in WorkflowExecutor.
@@ -37,6 +36,15 @@ internal fun WorkflowExecutor.scheduleTimerForContinuation(
 
     createAndAddTimerCommand(seq, delayMillis)
     state.registerTimerContinuation(seq, continuation)
+
+    // If the delaying coroutine is cancelled before the timer fires, tell core to
+    // cancel the server-side timer. Teardown paths (terminal completion, eviction)
+    // clear the registry before cancelling, so no command is emitted there.
+    continuation.invokeOnCancellation {
+        if (!state.workflowCompleted && state.removeTimerContinuation(seq)) {
+            createAndAddCancelTimerCommand(seq)
+        }
+    }
 }
 
 /**
@@ -54,6 +62,10 @@ internal fun WorkflowExecutor.scheduleTimeoutCallbackTimer(
     delayMillis: Long,
     block: Runnable,
 ): kotlinx.coroutines.DisposableHandle {
+    // Consume the one-shot summary handoff (set by awaitCondition's timeout path)
+    // even on the immediate-execution path, so it can never leak to a later timer
+    val summary = state.consumePendingTimerSummary()
+
     // Handle zero or negative delay - execute immediately
     if (delayMillis <= 0) {
         logger.debug("Timeout with zero/negative delay ({}ms), executing immediately", delayMillis)
@@ -66,7 +78,7 @@ internal fun WorkflowExecutor.scheduleTimeoutCallbackTimer(
     val seq = state.nextSeq()
     logger.debug("Scheduling timeout callback: seq={}, delay={}ms", seq, delayMillis)
 
-    createAndAddTimerCommand(seq, delayMillis)
+    createAndAddTimerCommand(seq, delayMillis, summary)
     state.registerTimeoutCallback(seq, block)
 
     // Return a handle that can cancel the timeout
@@ -82,21 +94,16 @@ internal fun WorkflowExecutor.scheduleTimeoutCallbackTimer(
  *
  * @param seq The sequence number for the timer
  * @param delayMillis The delay in milliseconds
+ * @param summary Optional UI-facing summary, carried as user metadata on the command
  */
 internal fun WorkflowExecutor.createAndAddTimerCommand(
     seq: Int,
     delayMillis: Long,
+    summary: String? = null,
 ) {
-    val duration = delayMillis.milliseconds
-    val javaDuration = duration.toJavaDuration()
-    val protoDuration =
-        com.google.protobuf.Duration
-            .newBuilder()
-            .setSeconds(javaDuration.seconds)
-            .setNanos(javaDuration.nano)
-            .build()
+    val protoDuration = delayMillis.milliseconds.toProtoDuration()
 
-    val command =
+    val commandBuilder =
         WorkflowCommands.WorkflowCommand
             .newBuilder()
             .setStartTimer(
@@ -104,9 +111,11 @@ internal fun WorkflowExecutor.createAndAddTimerCommand(
                     .newBuilder()
                     .setSeq(seq)
                     .setStartToFireTimeout(protoDuration),
-            ).build()
+            )
 
-    state.addCommand(command)
+    summary?.let { commandBuilder.setUserMetadata(buildUserMetadata(serializer, it)) }
+
+    state.addCommand(commandBuilder.build())
 }
 
 /**

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorUpdates.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorUpdates.kt
@@ -8,6 +8,7 @@ import com.surrealdev.temporal.common.EncodedTemporalPayloads
 import com.surrealdev.temporal.common.TemporalPayload
 import com.surrealdev.temporal.common.TemporalPayloads
 import com.surrealdev.temporal.common.failure.FAILURE_SOURCE
+import com.surrealdev.temporal.internal.isFatalError
 import com.surrealdev.temporal.serialization.safeDecode
 import com.surrealdev.temporal.serialization.safeEncodeSingle
 import com.surrealdev.temporal.serialization.safeSerialize
@@ -129,7 +130,11 @@ internal suspend fun WorkflowExecutor.handleUpdate(
             pendingActivationFailure = e
         } catch (e: Throwable) {
             val cause = (e as? java.lang.reflect.InvocationTargetException)?.targetException ?: e
-            if (!accepted || cause.isWorkflowFailureException()) {
+            if (cause.isFatalError()) {
+                // A fatal JVM error (OOM etc.) must shut the worker down, never
+                // become a rejection: fail the task so activate() surfaces it.
+                pendingActivationFailure = cause
+            } else if (!accepted || cause.isWorkflowFailureException()) {
                 // Validation-phase exceptions reject the update (that's what validators
                 // are for); after acceptance, only failure-typed exceptions resolve the
                 // update as failed. The proto explicitly permits rejected-after-accepted.

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorUpdates.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowExecutorUpdates.kt
@@ -7,7 +7,6 @@ import com.surrealdev.temporal.application.plugin.interceptor.ValidateUpdateInpu
 import com.surrealdev.temporal.common.EncodedTemporalPayloads
 import com.surrealdev.temporal.common.TemporalPayload
 import com.surrealdev.temporal.common.TemporalPayloads
-import com.surrealdev.temporal.common.exceptions.PayloadProcessingException
 import com.surrealdev.temporal.common.failure.FAILURE_SOURCE
 import com.surrealdev.temporal.serialization.safeDecode
 import com.surrealdev.temporal.serialization.safeEncodeSingle
@@ -74,6 +73,7 @@ internal suspend fun WorkflowExecutor.handleUpdate(
     val ctx = (context ?: error("WorkflowContext not initialized"))
 
     ctx.launchHandler {
+        var accepted = false
         try {
             // ValidateUpdate interceptor chain — terminal handler runs the actual validator
             if (runValidator) {
@@ -100,6 +100,7 @@ internal suspend fun WorkflowExecutor.handleUpdate(
 
             // Accept the update
             addUpdateAcceptedCommand(protocolInstanceId)
+            accepted = true
 
             // ExecuteUpdate interceptor chain — terminal handler runs the actual handler
             val executeInput =
@@ -118,30 +119,32 @@ internal suspend fun WorkflowExecutor.handleUpdate(
 
             // Complete with result
             addUpdateCompletedCommand(protocolInstanceId, resultPayload as Payload)
-        } catch (e: PayloadProcessingException) {
-            logger.warn("Update handler payload processing failed for '{}': {}", updateName, e.message)
-            addUpdateRejectedCommand(protocolInstanceId, "Failed to process update arguments: ${e.message}")
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Coroutine cancellation (teardown/eviction) - never convert to a response
+            throw e
         } catch (e: ReadOnlyContextException) {
+            // A validator mutating state is a coding bug: fail the workflow task
+            // (retryable) rather than permanently rejecting the update. Python parity.
             logger.warn("Update validator attempted state mutation: {}", e.message)
-            addUpdateRejectedCommand(protocolInstanceId, "Validator attempted state mutation: ${e.message}")
-        } catch (e: java.lang.reflect.InvocationTargetException) {
-            val cause = e.targetException ?: e
-            if (cause is IllegalArgumentException) {
-                logger.warn("Update validation failed: {}", cause.message)
-                addUpdateRejectedCommand(protocolInstanceId, cause.message ?: "Validation failed")
-            } else {
-                logger.warn("Update handler threw exception: {}", cause.message, cause)
+            pendingActivationFailure = e
+        } catch (e: Throwable) {
+            val cause = (e as? java.lang.reflect.InvocationTargetException)?.targetException ?: e
+            if (!accepted || cause.isWorkflowFailureException()) {
+                // Validation-phase exceptions reject the update (that's what validators
+                // are for); after acceptance, only failure-typed exceptions resolve the
+                // update as failed. The proto explicitly permits rejected-after-accepted.
+                logger.warn("Update '{}' rejected: {}", updateName, cause.message)
                 addUpdateRejectedCommand(
                     protocolInstanceId,
-                    "Update failed: ${cause.message ?: cause::class.simpleName}",
+                    cause.message ?: "Update failed: ${cause::class.simpleName}",
                 )
+            } else {
+                // An accepted update whose handler throws a non-failure exception is a
+                // bug: fail the workflow task (retryable) so the update can complete
+                // once the worker is fixed. Python parity.
+                logger.warn("Update handler threw non-failure exception: {}", cause.message, cause)
+                pendingActivationFailure = cause
             }
-        } catch (e: IllegalArgumentException) {
-            logger.warn("Update validation failed: {}", e.message)
-            addUpdateRejectedCommand(protocolInstanceId, e.message ?: "Validation failed")
-        } catch (e: Exception) {
-            logger.warn("Update handler threw exception: {}", e.message, e)
-            addUpdateRejectedCommand(protocolInstanceId, "Update failed: ${e.message ?: e::class.simpleName}")
         }
     }
 }

--- a/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowState.kt
+++ b/core/src/main/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowState.kt
@@ -89,7 +89,26 @@ internal class WorkflowState(
      * Once true, remains true for the lifetime of the workflow run.
      */
     var cancelRequested: Boolean = false
-        internal set
+
+    /** User-specified reason from the CancelWorkflow job, if any. */
+    var cancelReason: String? = null
+
+    /**
+     * One-shot handoff of a UI-facing summary to the next timer created via the
+     * kotlinx `withTimeout` interception (used by awaitCondition's timeout).
+     *
+     * `withTimeout` schedules its timeout timer synchronously in the caller's stack
+     * via the dispatcher's `invokeOnTimeout`, and workflow code is single-threaded,
+     * so set-then-consume within one call stack is deterministic and replay-safe.
+     */
+    var pendingTimerSummary: String? = null
+
+    /** Consumes (returns and clears) [pendingTimerSummary]. */
+    fun consumePendingTimerSummary(): String? {
+        val summary = pendingTimerSummary
+        pendingTimerSummary = null
+        return summary
+    }
 
     /**
      * Whether the workflow is currently replaying past events.
@@ -318,6 +337,21 @@ internal class WorkflowState(
     fun cancelTimeoutCallback(seq: Int): Boolean = pendingTimeoutCallbacks.remove(seq) != null
 
     /**
+     * Removes a pending deferred-based timer without resolving it.
+     * Used when the sleeping coroutine is cancelled and the SDK needs to know
+     * whether a CancelTimer command should be emitted.
+     *
+     * @return true if the timer was still pending (not yet fired/removed)
+     */
+    fun removeTimer(seq: Int): Boolean = pendingTimers.remove(seq) != null
+
+    /**
+     * Removes a pending continuation-based timer without resuming it.
+     * See [removeTimer].
+     */
+    fun removeTimerContinuation(seq: Int): Boolean = pendingTimerContinuations.remove(seq) != null
+
+    /**
      * Resolves a timer by its sequence number.
      * Called when a FireTimer job is received in an activation.
      * Handles deferred-based, continuation-based, and callback-based timers.
@@ -359,7 +393,12 @@ internal class WorkflowState(
         seq: Int,
         result: ActivityResult.ActivityResolution,
     ) {
-        val handle = pendingActivities.remove(seq) ?: return
+        // An unknown seq is a correlation bug: silently ignoring it would leave the
+        // awaiting coroutine suspended forever (hung workflow). Failing loudly turns it
+        // into a retryable workflow task failure, matching the Python SDK.
+        val handle =
+            pendingActivities.remove(seq)
+                ?: error("Failed to find activity handle for sequence number $seq")
         handle.resolve(result)
     }
 
@@ -465,7 +504,10 @@ internal class WorkflowState(
         seq: Int,
         resolution: ResolveChildWorkflowExecutionStart,
     ) {
-        val handle = pendingChildWorkflows[seq] ?: return
+        // See resolveActivity: unknown seqs must fail the task, not hang the workflow
+        val handle =
+            pendingChildWorkflows[seq]
+                ?: error("Failed to find child workflow handle for sequence number $seq")
         handle.resolveStart(resolution)
 
         // If start failed, remove from pending (no execution resolution will come)
@@ -482,7 +524,10 @@ internal class WorkflowState(
         seq: Int,
         result: ChildWorkflow.ChildWorkflowResult,
     ) {
-        val handle = pendingChildWorkflows.remove(seq) ?: return
+        // See resolveActivity: unknown seqs must fail the task, not hang the workflow
+        val handle =
+            pendingChildWorkflows.remove(seq)
+                ?: error("Failed to find child workflow handle for sequence number $seq")
         handle.resolveExecution(result)
     }
 
@@ -506,6 +551,15 @@ internal class WorkflowState(
     }
 
     /**
+     * Removes a pending external signal without resolving it.
+     * Used when the awaiting coroutine is cancelled and the SDK needs to know whether
+     * a CancelSignalWorkflow command should be emitted.
+     *
+     * @return true if the signal was still pending
+     */
+    fun removeExternalSignal(seq: Int): Boolean = pendingExternalSignals.remove(seq) != null
+
+    /**
      * Resolves an external signal by its sequence number.
      * Called when a ResolveSignalExternalWorkflow job is received.
      *
@@ -516,6 +570,10 @@ internal class WorkflowState(
         seq: Int,
         failure: io.temporal.api.failure.v1.Failure?,
     ) {
+        // The awaiting coroutine may have been cancelled (which rescinds the signal via
+        // CancelSignalWorkflow); a resolution racing that cancel is legitimate, so a
+        // missing entry is only ignored here - unlike activities/children, no coroutine
+        // can be left hanging.
         val deferred = pendingExternalSignals.remove(seq) ?: return
         deferred.complete(failure)
     }
@@ -795,13 +853,18 @@ internal class WorkflowState(
      * Called on workflow eviction or completion.
      */
     fun clear() {
-        // Cancel all pending timers (deferred-based)
-        pendingTimers.values.forEach { it.cancel() }
+        // Cancel all pending timers (deferred-based).
+        // Snapshot + clear BEFORE cancelling: cancellation handlers on sleeping
+        // coroutines emit CancelTimer commands only while their entry is still
+        // registered, and teardown must not emit commands.
+        val timers = pendingTimers.values.toList()
         pendingTimers.clear()
+        timers.forEach { it.cancel() }
 
-        // Cancel all pending timers (continuation-based)
-        pendingTimerContinuations.values.forEach { it.cancel() }
+        // Cancel all pending timers (continuation-based) - same ordering rationale
+        val timerContinuations = pendingTimerContinuations.values.toList()
         pendingTimerContinuations.clear()
+        timerContinuations.forEach { it.cancel() }
 
         // Clear all pending timeout callbacks (no need to cancel, just discard)
         pendingTimeoutCallbacks.clear()
@@ -813,16 +876,20 @@ internal class WorkflowState(
         // Clear all pending local activities
         pendingLocalActivities.clear()
 
-        // Cancel all pending child workflows
-        pendingChildWorkflows.values.forEach {
+        // Cancel all pending child workflows - snapshot + clear BEFORE cancelling so
+        // awaiting coroutines' cancellation handlers don't emit cancel commands
+        val childWorkflows = pendingChildWorkflows.values.toList()
+        pendingChildWorkflows.clear()
+        childWorkflows.forEach {
             it.startDeferred.cancel()
             it.executionDeferred.cancel()
         }
-        pendingChildWorkflows.clear()
 
-        // Cancel all pending external signals
-        pendingExternalSignals.values.forEach { it.cancel() }
+        // Cancel all pending external signals - snapshot + clear BEFORE cancelling so
+        // awaiting coroutines' cancellation handlers don't emit cancel commands
+        val externalSignals = pendingExternalSignals.values.toList()
         pendingExternalSignals.clear()
+        externalSignals.forEach { it.cancel() }
 
         // Cancel all pending external cancels
         pendingExternalCancels.values.forEach { it.cancel() }

--- a/core/src/test/kotlin/com/surrealdev/temporal/activity/integration/ExceptionPropagationIntegrationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/activity/integration/ExceptionPropagationIntegrationTest.kt
@@ -12,6 +12,7 @@ import com.surrealdev.temporal.common.exceptions.ChildWorkflowFailureException
 import com.surrealdev.temporal.common.exceptions.ClientWorkflowFailedException
 import com.surrealdev.temporal.common.exceptions.WorkflowActivityFailureException
 import com.surrealdev.temporal.testing.assertHistory
+import com.surrealdev.temporal.testing.awaitHistory
 import com.surrealdev.temporal.testing.runTemporalTest
 import com.surrealdev.temporal.workflow.ActivityOptions
 import com.surrealdev.temporal.workflow.ChildWorkflowOptions
@@ -533,18 +534,9 @@ class ExceptionPropagationIntegrationTest {
             // Non-failure-typed exceptions are bugs: they fail the workflow TASK (retryable)
             // and the workflow stays running, matching Python/Java SDK semantics. Only
             // failure-typed exceptions (ApplicationFailure etc.) fail the workflow.
-            val deadline = System.currentTimeMillis() + 10_000
-            var taskFailure: TemporalHistoryEvent.WorkflowTaskFailed? = null
-            while (System.currentTimeMillis() < deadline) {
-                val history = handle.getHistory()
-                taskFailure =
-                    history
-                        .filterByType<TemporalHistoryEvent.WorkflowTaskFailed>()
-                        .firstOrNull()
-                if (taskFailure != null) break
-                kotlinx.coroutines.delay(200)
+            handle.awaitHistory(description = "a WorkflowTaskFailed event") {
+                it.filterByType<TemporalHistoryEvent.WorkflowTaskFailed>().isNotEmpty()
             }
-            assertNotNull(taskFailure, "Expected a WorkflowTaskFailed event in history")
 
             val description = handle.describe()
             assertEquals(

--- a/core/src/test/kotlin/com/surrealdev/temporal/activity/integration/ExceptionPropagationIntegrationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/activity/integration/ExceptionPropagationIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.surrealdev.temporal.annotation.Activity
 import com.surrealdev.temporal.annotation.Workflow
 import com.surrealdev.temporal.annotation.WorkflowRun
 import com.surrealdev.temporal.application.taskQueue
+import com.surrealdev.temporal.client.history.TemporalHistoryEvent
 import com.surrealdev.temporal.client.startWorkflow
 import com.surrealdev.temporal.common.RetryPolicy
 import com.surrealdev.temporal.common.exceptions.ApplicationFailure
@@ -297,7 +298,8 @@ class ExceptionPropagationIntegrationTest {
     @Workflow("WorkflowStackTraceCutoffWF")
     class WorkflowStackTraceCutoffWorkflow {
         @WorkflowRun
-        suspend fun WorkflowContext.run(): String = throw IllegalStateException("workflow failed for trace cutoff test")
+        suspend fun WorkflowContext.run(): String =
+            throw ApplicationFailure.failure("workflow failed for trace cutoff test")
     }
 
     @Test
@@ -511,8 +513,8 @@ class ExceptionPropagationIntegrationTest {
     }
 
     @Test
-    fun `workflow regular exception propagates as ClientWorkflowFailedException`() =
-        runTemporalTest(timeSkipping = true) {
+    fun `workflow regular exception fails the task and does not fail the workflow`() =
+        runTemporalTest {
             val taskQueue = "test-excprop-c1-${UUID.randomUUID()}"
 
             application {
@@ -528,39 +530,30 @@ class ExceptionPropagationIntegrationTest {
                     taskQueue = taskQueue,
                 )
 
-            val exception =
-                assertFailsWith<ClientWorkflowFailedException> {
-                    handle.result<String>(timeout = 30.seconds)
-                }
+            // Non-failure-typed exceptions are bugs: they fail the workflow TASK (retryable)
+            // and the workflow stays running, matching Python/Java SDK semantics. Only
+            // failure-typed exceptions (ApplicationFailure etc.) fail the workflow.
+            val deadline = System.currentTimeMillis() + 10_000
+            var taskFailure: TemporalHistoryEvent.WorkflowTaskFailed? = null
+            while (System.currentTimeMillis() < deadline) {
+                val history = handle.getHistory()
+                taskFailure =
+                    history
+                        .filterByType<TemporalHistoryEvent.WorkflowTaskFailed>()
+                        .firstOrNull()
+                if (taskFailure != null) break
+                kotlinx.coroutines.delay(200)
+            }
+            assertNotNull(taskFailure, "Expected a WorkflowTaskFailed event in history")
 
-            // All exceptions are wrapped with ApplicationFailureInfo at proto level
-            // (matching Python SDK behavior), so applicationFailure is always present
-            val appFailure = exception.applicationFailure
-            assertNotNull(appFailure, "Should have applicationFailure (all exceptions wrapped)")
-            // The ApplicationFailure type preserves the original exception class name
-            assertEquals("java.lang.IllegalStateException", appFailure.type)
-            // Regular exceptions are retryable
-            assertEquals(false, appFailure.isNonRetryable, "Regular exceptions should be retryable")
-            // Original message preserved
-            assertEquals("workflow regular failure", appFailure.originalMessage)
-            // Cause is ApplicationFailure (reconstructed from proto with ApplicationFailureInfo)
-            assertTrue(exception.cause is ApplicationFailure, "Cause should be ApplicationFailure: ${exception.cause}")
-            // Workflow ID populated
-            assertTrue(exception.workflowId.isNotEmpty(), "workflowId should be populated")
-
-            // Java stack trace should reference the workflow class, not buildCause
-            val hasWorkflowFrame =
-                appFailure.stackTrace.any {
-                    it.className.contains("ThrowRegularExceptionWorkflow")
-                }
-            assertTrue(
-                hasWorkflowFrame,
-                "Stack trace should reference ThrowRegularExceptionWorkflow, got: ${appFailure.stackTrace.toList()}",
+            val description = handle.describe()
+            assertEquals(
+                com.surrealdev.temporal.client.WorkflowExecutionStatus.RUNNING,
+                description.status,
+                "Workflow should still be running after a task failure",
             )
 
-            handle.assertHistory {
-                failed()
-            }
+            handle.terminate("test cleanup")
         }
 
     @Workflow("ThrowApplicationFailureWF")
@@ -680,7 +673,12 @@ class ExceptionPropagationIntegrationTest {
     @Workflow("FailingChildRegularExWF")
     class FailingChildRegularExWorkflow {
         @WorkflowRun
-        suspend fun WorkflowContext.run(): String = throw IllegalStateException("child regular failure")
+        suspend fun WorkflowContext.run(): String =
+            throw ApplicationFailure.failure(
+                message = "child regular failure",
+                type = "ChildRegularError",
+                cause = IllegalStateException("child regular failure"),
+            )
     }
 
     @Workflow("FailingChildAppFailureWF")
@@ -769,15 +767,14 @@ class ExceptionPropagationIntegrationTest {
             val result = handle.result<String>(timeout = 30.seconds)
 
             assertTrue(result.contains("exType=ChildWorkflowFailureException"), "Wrong type: $result")
-            // applicationFailure is present because all exceptions are wrapped with ApplicationFailureInfo
             assertTrue(result.contains("appFailure=true"), "Should have applicationFailure: $result")
-            // Type preserves the original exception class name
+            // Explicit failure type is preserved through the proto boundary
             assertTrue(
-                result.contains("appFailureType=java.lang.IllegalStateException"),
-                "Type should be original class: $result",
+                result.contains("appFailureType=ChildRegularError"),
+                "Type should be preserved: $result",
             )
-            // Regular exceptions are retryable
-            assertTrue(result.contains("appFailureNR=false"), "Regular exceptions should be retryable: $result")
+            // Retryable failures stay retryable
+            assertTrue(result.contains("appFailureNR=false"), "Retryable failures should stay retryable: $result")
             // Original message should be somewhere in the cause chain
             assertTrue(result.contains("hasOriginalMsg=true"), "Original message lost in cause chain: $result")
 

--- a/core/src/test/kotlin/com/surrealdev/temporal/testing/ProtoTestHelpers.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/testing/ProtoTestHelpers.kt
@@ -561,8 +561,8 @@ object ProtoTestHelpers {
     /**
      * Creates a CancelWorkflow job.
      */
-    fun cancelWorkflowJob(): WorkflowActivationJob {
-        val cancel = CancelWorkflow.newBuilder().build()
+    fun cancelWorkflowJob(reason: String = ""): WorkflowActivationJob {
+        val cancel = CancelWorkflow.newBuilder().setReason(reason).build()
 
         return WorkflowActivationJob
             .newBuilder()

--- a/core/src/test/kotlin/com/surrealdev/temporal/testing/TestApplicationStub.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/testing/TestApplicationStub.kt
@@ -26,6 +26,51 @@ internal fun createStubApplication(): TemporalApplication =
     }
 
 /**
+ * A minimal workflow that parks forever, for tests that exercise activation/job
+ * processing without caring about the workflow body. Unlike a dummy reflection
+ * target, this is a real suspend workflow: the executor keeps it alive across
+ * activations and never emits terminal commands or task failures on its behalf.
+ */
+class IdleTestWorkflow {
+    suspend fun com.surrealdev.temporal.workflow.WorkflowContext.run(): String {
+        awaitCondition { false }
+        return "unreachable"
+    }
+}
+
+/**
+ * Creates a WorkflowExecutor whose workflow is an [IdleTestWorkflow] parked on
+ * `awaitCondition { false }` - useful for job-processing tests.
+ */
+internal fun createIdleTestWorkflowExecutor(
+    runId: String = "test-run-id",
+    workflowType: String = "TestWorkflow",
+    serializer: PayloadSerializer = CompositePayloadSerializer.default(),
+): WorkflowExecutor {
+    val workflow = IdleTestWorkflow()
+    val runMethod =
+        IdleTestWorkflow::class
+            .members
+            .first { it.name == "run" } as kotlin.reflect.KFunction<*>
+    val methodInfo =
+        WorkflowMethodInfo(
+            workflowType = workflowType,
+            runMethod = runMethod,
+            workflowClass = IdleTestWorkflow::class,
+            instanceFactory = { workflow },
+            parameterTypes = emptyList(),
+            returnType = kotlin.reflect.typeOf<String>(),
+            hasContextReceiver = true,
+            isSuspend = true,
+        )
+    return createTestWorkflowExecutor(
+        runId = runId,
+        methodInfo = methodInfo,
+        serializer = serializer,
+    )
+}
+
+/**
  * Creates a WorkflowExecutor for use in tests.
  *
  * @param runId The workflow run ID

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ChildWorkflowIntegrationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ChildWorkflowIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.surrealdev.temporal.annotation.Workflow
 import com.surrealdev.temporal.annotation.WorkflowRun
 import com.surrealdev.temporal.application.taskQueue
 import com.surrealdev.temporal.client.startWorkflow
+import com.surrealdev.temporal.common.exceptions.ApplicationFailure
 import com.surrealdev.temporal.common.exceptions.ChildWorkflowFailureException
 import com.surrealdev.temporal.testing.assertHistory
 import com.surrealdev.temporal.testing.runTemporalTest
@@ -69,12 +70,13 @@ class ChildWorkflowIntegrationTest {
     }
 
     /**
-     * Child workflow that fails intentionally.
+     * Child workflow that fails intentionally with a failure-typed exception.
      */
     @Workflow("FailingChildWorkflow")
     class FailingChildWorkflow {
         @WorkflowRun
-        suspend fun WorkflowContext.run(): String = throw IllegalStateException("Child workflow intentional failure")
+        suspend fun WorkflowContext.run(): String =
+            throw ApplicationFailure.failure("Child workflow intentional failure")
     }
 
     /**

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ContextEscape.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ContextEscape.kt
@@ -5,6 +5,7 @@ import com.surrealdev.temporal.annotation.WorkflowRun
 import com.surrealdev.temporal.application.taskQueue
 import com.surrealdev.temporal.client.startWorkflow
 import com.surrealdev.temporal.testing.assertHistory
+import com.surrealdev.temporal.testing.awaitHistory
 import com.surrealdev.temporal.testing.runTemporalTest
 import com.surrealdev.temporal.workflow.ChildWorkflowOptions
 import com.surrealdev.temporal.workflow.WorkflowContext
@@ -353,18 +354,16 @@ class ContextEscape {
             // An EscapedDispatcherException is a coding bug, not a business failure:
             // the workflow TASK fails (retryable, TKT1108 visible in history) and the
             // workflow stays running rather than failing permanently.
-            val deadline = System.currentTimeMillis() + 15_000
-            var taskFailure: com.surrealdev.temporal.client.history.TemporalHistoryEvent.WorkflowTaskFailed? = null
-            while (System.currentTimeMillis() < deadline) {
-                taskFailure =
-                    handle
-                        .getHistory()
+            val history =
+                handle.awaitHistory(timeout = 15.seconds, description = "a WorkflowTaskFailed event") {
+                    it
                         .filterByType<com.surrealdev.temporal.client.history.TemporalHistoryEvent.WorkflowTaskFailed>()
-                        .firstOrNull()
-                if (taskFailure != null) break
-                delay(200.milliseconds)
-            }
-            assertTrue(taskFailure != null, "Expected a WorkflowTaskFailed event in history")
+                        .isNotEmpty()
+                }
+            val taskFailure =
+                history
+                    .filterByType<com.surrealdev.temporal.client.history.TemporalHistoryEvent.WorkflowTaskFailed>()
+                    .first()
             assertEquals(
                 taskFailure.failureMessage?.contains("TKT1108"),
                 true,

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ContextEscape.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/integration/ContextEscape.kt
@@ -333,7 +333,7 @@ class ContextEscape {
         }
 
     @Test
-    fun `workflow operation inside escaped context should fail`() =
+    fun `workflow operation inside escaped context fails the workflow task`() =
         runTemporalTest(timeSkipping = false) {
             val taskQueue = "test-escape-op-fail-${UUID.randomUUID()}"
 
@@ -350,18 +350,28 @@ class ContextEscape {
                     taskQueue = taskQueue,
                 )
 
-            // This should fail - workflow operations from escaped context should throw
-            val exception =
-                org.junit.jupiter.api.assertThrows<Exception> {
-                    handle.result(timeout = 30.seconds)
-                }
-            // Verify it's our specific exception
-            assertTrue(
-                exception.message?.contains("TKT1108") == true ||
-                    exception.cause?.message?.contains("TKT1108") == true,
-                "Expected EscapedDispatcherException with TKT1108, got: ${exception.message}",
+            // An EscapedDispatcherException is a coding bug, not a business failure:
+            // the workflow TASK fails (retryable, TKT1108 visible in history) and the
+            // workflow stays running rather than failing permanently.
+            val deadline = System.currentTimeMillis() + 15_000
+            var taskFailure: com.surrealdev.temporal.client.history.TemporalHistoryEvent.WorkflowTaskFailed? = null
+            while (System.currentTimeMillis() < deadline) {
+                taskFailure =
+                    handle
+                        .getHistory()
+                        .filterByType<com.surrealdev.temporal.client.history.TemporalHistoryEvent.WorkflowTaskFailed>()
+                        .firstOrNull()
+                if (taskFailure != null) break
+                delay(200.milliseconds)
+            }
+            assertTrue(taskFailure != null, "Expected a WorkflowTaskFailed event in history")
+            assertEquals(
+                taskFailure.failureMessage?.contains("TKT1108"),
+                true,
+                "Expected EscapedDispatcherException with TKT1108, got: ${taskFailure.failureMessage}",
             )
-            println("Got expected exception: ${exception.message}")
+
+            handle.terminate("test cleanup")
         }
 
     /**

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ActivationReplayDeterminismTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ActivationReplayDeterminismTest.kt
@@ -5,14 +5,11 @@ import com.surrealdev.temporal.testing.ProtoTestHelpers.fireTimerJob
 import com.surrealdev.temporal.testing.ProtoTestHelpers.initializeWorkflowJob
 import com.surrealdev.temporal.testing.ProtoTestHelpers.timestamp
 import com.surrealdev.temporal.testing.ProtoTestHelpers.updateRandomSeedJob
-import com.surrealdev.temporal.testing.createTestWorkflowExecutor
 import coresdk.workflow_commands.WorkflowCommands.WorkflowCommand
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import java.util.UUID
-import kotlin.reflect.KFunction
-import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -398,26 +395,7 @@ class ActivationReplayDeterminismTest {
     // Helper Methods
     // ================================================================
 
-    private fun createTestExecutor(): WorkflowExecutor {
-        // Get a simple method for the WorkflowMethodInfo
-        val dummyMethod =
-            this::class
-                .members
-                .first { it.name == "createTestExecutor" } as KFunction<*>
-
-        val testInstance = this
-        val workflowMethodInfo =
-            WorkflowMethodInfo(
-                workflowType = "TestWorkflow",
-                runMethod = dummyMethod,
-                workflowClass = this::class,
-                instanceFactory = { testInstance },
-                parameterTypes = emptyList(),
-                returnType = typeOf<Unit>(),
-                hasContextReceiver = false,
-                isSuspend = false,
-            )
-
-        return createTestWorkflowExecutor(methodInfo = workflowMethodInfo)
-    }
+    private fun createTestExecutor(): WorkflowExecutor =
+        com.surrealdev.temporal.testing
+            .createIdleTestWorkflowExecutor()
 }

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ActivityActivationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ActivityActivationTest.kt
@@ -14,6 +14,7 @@ import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveActivityJobCancel
 import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveActivityJobCompleted
 import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveActivityJobFailed
 import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.workflow.ActivityCancellationType
 import com.surrealdev.temporal.workflow.ActivityOptions
 import com.surrealdev.temporal.workflow.WorkflowContext
 import com.surrealdev.temporal.workflow.result
@@ -886,6 +887,74 @@ class ActivityActivationTest {
             val handleSnapshotAfter = workflow.handle
             assertNotNull(handleSnapshotAfter)
             assertTrue(handleSnapshotAfter.isDone)
+        }
+
+    @Workflow("AbandonCancellationWorkflow")
+    class AbandonCancellationWorkflow {
+        var cancellationResult: String? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            val handle =
+                startActivity(
+                    activityType = "TestActivity::abandoned",
+                    options =
+                        ActivityOptions(
+                            startToCloseTimeout = 30.seconds,
+                            cancellationType = ActivityCancellationType.ABANDON,
+                        ),
+                )
+
+            handle.cancel("Abandoning activity")
+
+            cancellationResult =
+                try {
+                    handle.result()
+                } catch (e: WorkflowActivityCancelledException) {
+                    "Activity was abandoned: ${e.activityType}"
+                }
+            return cancellationResult!!
+        }
+    }
+
+    @Test
+    fun `ABANDON cancellation still emits RequestCancelActivity command`() =
+        runTest {
+            val result = createExecutorWithWorkflow<AbandonCancellationWorkflow>("AbandonCancellationWorkflow")
+
+            // Core SDK owns ABANDON semantics: lang must send the cancel command and core
+            // resolves the activity as cancelled immediately without a server round trip
+            // (activity_state_machine on_abandoned). Not sending the command leaves the
+            // workflow waiting on the activity's natural resolution.
+            val commands = getCommandsFromCompletion(result.completion)
+            assertEquals(2, commands.size)
+            assertTrue(commands[0].hasScheduleActivity())
+            assertTrue(commands[1].hasRequestCancelActivity())
+            assertEquals(commands[0].scheduleActivity.seq, commands[1].requestCancelActivity.seq)
+        }
+
+    @Test
+    fun `ABANDON cancelled activity resolves with cancellation when core reports it`() =
+        runTest {
+            val result = createExecutorWithWorkflow<AbandonCancellationWorkflow>("AbandonCancellationWorkflow")
+            val workflow = result.workflow as AbandonCancellationWorkflow
+
+            val commands = getCommandsFromCompletion(result.completion)
+            val seq = commands[0].scheduleActivity.seq
+
+            val completion =
+                result.executor
+                    .activate(
+                        createActivation(
+                            runId = result.runId,
+                            jobs = listOf(resolveActivityJobCancelled(seq)),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(completion.hasSuccessful())
+            assertNotNull(workflow.cancellationResult)
+            assertTrue(workflow.cancellationResult!!.contains("Activity was abandoned"))
         }
 
     @Test

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ChildWorkflowTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/ChildWorkflowTest.kt
@@ -22,6 +22,7 @@ import com.surrealdev.temporal.workflow.WorkflowContext
 import com.surrealdev.temporal.workflow.result
 import com.surrealdev.temporal.workflow.signal
 import com.surrealdev.temporal.workflow.startChildWorkflow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import java.util.UUID
@@ -32,6 +33,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Comprehensive tests for child workflow functionality.
@@ -215,6 +217,119 @@ class ChildWorkflowTest {
 
             // Should be parent workflow ID + child + seq
             assertTrue(childCommand.startChildWorkflowExecution.workflowId.contains("-child-"))
+        }
+
+    @Workflow("ChildWithExtendedOptionsParent")
+    class ChildWithExtendedOptionsParent {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            startChildWorkflow(
+                "ChildWorkflow",
+                ChildWorkflowOptions(
+                    cronSchedule = "0 12 * * *",
+                    memo =
+                        mapOf(
+                            "note" to serializer.serialize<String>("memo-value"),
+                        ),
+                    versioningIntent = com.surrealdev.temporal.workflow.VersioningIntent.COMPATIBLE,
+                    workflowTaskTimeout = 10.seconds,
+                    priority = 2,
+                    summary = "child summary",
+                ),
+            )
+            awaitCondition { false }
+            return "done"
+        }
+
+        companion object {
+            val serializer = CompositePayloadSerializer.default()
+        }
+    }
+
+    @Test
+    fun `child workflow command includes extended options`() =
+        runTest {
+            val result = createInitializedExecutor(ChildWithExtendedOptionsParent())
+
+            val commands = getCommandsFromCompletion(result.completion)
+            val childCommand = commands.single { it.hasStartChildWorkflowExecution() }
+            val startChild = childCommand.startChildWorkflowExecution
+
+            assertEquals("0 12 * * *", startChild.cronSchedule)
+            assertTrue(startChild.memoMap.containsKey("note"), "memo should be set: ${startChild.memoMap}")
+            assertEquals(
+                coresdk.common.Common.VersioningIntent.COMPATIBLE,
+                startChild.versioningIntent,
+            )
+            assertEquals(10, startChild.workflowTaskTimeout.seconds)
+            assertEquals(2, startChild.priority.priorityKey)
+            assertTrue(childCommand.hasUserMetadata(), "summary should be carried as user metadata")
+            assertTrue(
+                childCommand.userMetadata.summary.data
+                    .toStringUtf8()
+                    .contains("child summary"),
+            )
+        }
+
+    @Workflow("ChildSignalCancelParent")
+    class ChildSignalCancelParent {
+        var handle: ChildWorkflowHandle? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            handle = startChildWorkflow("ChildWorkflow", ChildWorkflowOptions())
+            val signaler = launch { handle!!.signal("sig", "value") }
+            sleep(1.seconds)
+            signaler.cancel()
+            signaler.join()
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    /**
+     * Cancelling a coroutine awaiting an external-signal resolution must rescind the
+     * not-yet-sent signal with a CancelSignalWorkflow command (Python parity).
+     */
+    @Test
+    fun `cancelling a pending child signal emits CancelSignalWorkflow`() =
+        runTest {
+            val workflow = ChildSignalCancelParent()
+            val result = createInitializedExecutor(workflow)
+
+            val initCommands = getCommandsFromCompletion(result.completion)
+            val childSeq =
+                initCommands
+                    .single { it.hasStartChildWorkflowExecution() }
+                    .startChildWorkflowExecution.seq
+            val timerSeq =
+                initCommands
+                    .single { it.hasStartTimer() }
+                    .startTimer.seq
+
+            val completion =
+                result.executor
+                    .activate(
+                        createActivation(
+                            runId = result.runId,
+                            jobs =
+                                listOf(
+                                    resolveChildWorkflowStartJob(childSeq, "child-run-id"),
+                                    com.surrealdev.temporal.testing.ProtoTestHelpers
+                                        .fireTimerJob(timerSeq),
+                                ),
+                        ),
+                    ).completion
+
+            val commands = getCommandsFromCompletion(completion)
+            val signalCommand = commands.find { it.hasSignalExternalWorkflowExecution() }
+            assertNotNull(signalCommand, "signal should have been emitted, got: $commands")
+            val cancelSignal = commands.find { it.hasCancelSignalWorkflow() }
+            assertNotNull(cancelSignal, "CancelSignalWorkflow should rescind the pending signal, got: $commands")
+            assertEquals(
+                signalCommand.signalExternalWorkflowExecution.seq,
+                cancelSignal.cancelSignalWorkflow.seq,
+            )
         }
 
     // ================================================================
@@ -451,6 +566,67 @@ class ChildWorkflowTest {
             assertNotNull(startCommand, "Should have start command")
             assertNotNull(cancelCommand, "Should have cancel command")
             assertEquals(1, cancelCommand.cancelChildWorkflowExecution.childWorkflowSeq)
+            // The user-supplied reason must be propagated to the proto (Python parity)
+            assertEquals("Test cancellation", cancelCommand.cancelChildWorkflowExecution.reason)
+        }
+
+    @Workflow("ChildWorkflowScopeCancelParent")
+    class ChildWorkflowScopeCancelParent {
+        var handle: ChildWorkflowHandle? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            handle = startChildWorkflow("ChildWorkflow", ChildWorkflowOptions())
+            val waiter = launch { handle!!.result<String>() }
+            sleep(1.seconds)
+            waiter.cancel()
+            waiter.join()
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    /**
+     * Cancelling the coroutine that awaits a child workflow result must cancel the
+     * child itself (Python parity: `asyncio.wait_for(handle, t)` cancels the handle
+     * task, which sends cancel_child_workflow_execution). Without this, the standard
+     * `withTimeout { handle.result() }` pattern silently leaves the child running.
+     */
+    @Test
+    fun `cancelling the coroutine awaiting a child result emits CancelChildWorkflowExecution`() =
+        runTest {
+            val workflow = ChildWorkflowScopeCancelParent()
+            val result = createInitializedExecutor(workflow)
+
+            val initCommands = getCommandsFromCompletion(result.completion)
+            val childSeq =
+                initCommands
+                    .single { it.hasStartChildWorkflowExecution() }
+                    .startChildWorkflowExecution.seq
+            val timerSeq =
+                initCommands
+                    .single { it.hasStartTimer() }
+                    .startTimer.seq
+
+            // Child starts; then the timer fires, cancelling the awaiting coroutine
+            val completion =
+                result.executor
+                    .activate(
+                        createActivation(
+                            runId = result.runId,
+                            jobs =
+                                listOf(
+                                    resolveChildWorkflowStartJob(childSeq, "child-run-id"),
+                                    com.surrealdev.temporal.testing.ProtoTestHelpers
+                                        .fireTimerJob(timerSeq),
+                                ),
+                        ),
+                    ).completion
+
+            val commands = getCommandsFromCompletion(completion)
+            val cancelCommand = commands.find { it.hasCancelChildWorkflowExecution() }
+            assertNotNull(cancelCommand, "Cancelling the awaiting coroutine should cancel the child, got: $commands")
+            assertEquals(childSeq, cancelCommand.cancelChildWorkflowExecution.childWorkflowSeq)
         }
 
     // ================================================================

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/LocalActivityActivationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/LocalActivityActivationTest.kt
@@ -18,6 +18,7 @@ import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveLocalActivityJobF
 import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveLocalActivityJobFailedWithDetails
 import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveLocalActivityJobTimeout
 import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.workflow.ActivityCancellationType
 import com.surrealdev.temporal.workflow.LocalActivityOptions
 import com.surrealdev.temporal.workflow.WorkflowContext
 import com.surrealdev.temporal.workflow.result
@@ -146,6 +147,7 @@ class LocalActivityActivationTest {
                     scheduleToStartTimeout = 10.seconds,
                     activityId = "custom-la-id",
                     localRetryThreshold = 90.seconds,
+                    summary = "Configured local activity",
                 )
             startLocalActivity(
                 activityType = "configuredLocalActivity",
@@ -562,7 +564,8 @@ class LocalActivityActivationTest {
             val commands = getCommandsFromCompletion(initCompletion)
             assertTrue(commands.any { it.hasScheduleLocalActivity() }, "Should have ScheduleLocalActivity command")
 
-            val cmd = commands.first { it.hasScheduleLocalActivity() }.scheduleLocalActivity
+            val fullCmd = commands.first { it.hasScheduleLocalActivity() }
+            val cmd = fullCmd.scheduleLocalActivity
             assertEquals("custom-la-id", cmd.activityId)
             assertEquals("configuredLocalActivity", cmd.activityType)
             assertEquals(30, cmd.startToCloseTimeout.seconds)
@@ -571,6 +574,13 @@ class LocalActivityActivationTest {
             assertEquals(90, cmd.localRetryThreshold.seconds)
             // Default cancellation type should be WAIT_CANCELLATION_COMPLETED for local activities
             assertEquals(WorkflowCommands.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED, cmd.cancellationType)
+            // Summary is carried as user metadata on the wrapping WorkflowCommand
+            assertTrue(fullCmd.hasUserMetadata(), "WorkflowCommand should carry user metadata")
+            assertTrue(
+                fullCmd.userMetadata.summary.data
+                    .toStringUtf8()
+                    .contains("Configured local activity"),
+            )
         }
 
     /**
@@ -590,6 +600,50 @@ class LocalActivityActivationTest {
 
             val cancelCmd = commands.first { it.hasRequestCancelLocalActivity() }
             assertEquals(1, cancelCmd.requestCancelLocalActivity.seq)
+        }
+
+    @Workflow("AbandoningLocalActivityWorkflow")
+    class AbandoningLocalActivityWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            val handle =
+                startLocalActivity(
+                    activityType = "abandonedLocalActivity",
+                    options =
+                        LocalActivityOptions(
+                            startToCloseTimeout = 60.seconds,
+                            cancellationType = ActivityCancellationType.ABANDON,
+                        ),
+                )
+            handle.cancel("Abandoning local activity")
+            try {
+                handle.result()
+            } catch (_: Exception) {
+            }
+            return "done"
+        }
+    }
+
+    /**
+     * Core SDK owns ABANDON semantics: lang must still send the cancel command, and core's
+     * local activity machinery resolves the handle as cancelled immediately while letting
+     * the activity finish in the background. Skipping the command leaves result() suspended
+     * until the activity resolves naturally.
+     */
+    @Test
+    fun `ABANDON cancel sends RequestCancelLocalActivity command`() =
+        runTest {
+            val (_, _, _, initCompletion) =
+                createExecutorWithWorkflow<AbandoningLocalActivityWorkflow>("AbandoningLocalActivityWorkflow")
+
+            val commands = getCommandsFromCompletion(initCompletion)
+
+            assertTrue(commands.any { it.hasScheduleLocalActivity() })
+            assertTrue(commands.any { it.hasRequestCancelLocalActivity() })
+
+            val scheduleCmd = commands.first { it.hasScheduleLocalActivity() }.scheduleLocalActivity
+            val cancelCmd = commands.first { it.hasRequestCancelLocalActivity() }.requestCancelLocalActivity
+            assertEquals(scheduleCmd.seq, cancelCmd.seq)
         }
 
     // ================================================================

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/PatchHandlerTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/PatchHandlerTest.kt
@@ -191,28 +191,135 @@ class PatchHandlerTest {
         }
 
     // ================================================================
+    // Patch/Init Ordering (replay determinism)
+    // ================================================================
+
+    @com.surrealdev.temporal.annotation.Workflow("PatchedAtStartWorkflow")
+    class PatchedAtStartWorkflow {
+        var sawPatch: Boolean? = null
+
+        @com.surrealdev.temporal.annotation.WorkflowRun
+        suspend fun com.surrealdev.temporal.workflow.WorkflowContext.run(): String {
+            // Call patched() before the first suspension - the value must be identical
+            // on the original run (true) and on replay (requires NotifyHasPatch to be
+            // applied BEFORE the workflow body runs).
+            sawPatch = patched("my-patch")
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    /**
+     * On replay after eviction, core bundles NotifyHasPatch with InitializeWorkflow in a
+     * single activation. Patch notifications must be applied before the workflow body first
+     * runs, or `patched()` called before the first suspension returns false on replay
+     * (true on the original run) - a nondeterminism bug. Mirrors Python's job ordering,
+     * where patches are job set 0 and initialize-workflow is set 2.
+     */
+    @Test
+    fun `patch notification bundled with init is visible to workflow code on replay`() =
+        runTest {
+            val workflow = PatchedAtStartWorkflow()
+            val runMethod =
+                PatchedAtStartWorkflow::class
+                    .members
+                    .first { it.name == "run" } as KFunction<*>
+            val methodInfo =
+                WorkflowMethodInfo(
+                    workflowType = "PatchedAtStartWorkflow",
+                    runMethod = runMethod,
+                    workflowClass = PatchedAtStartWorkflow::class,
+                    instanceFactory = { workflow },
+                    parameterTypes = emptyList(),
+                    returnType = typeOf<String>(),
+                    hasContextReceiver = true,
+                    isSuspend = true,
+                )
+            val runId = "test-run-${UUID.randomUUID()}"
+            val executor =
+                createTestWorkflowExecutor(
+                    runId = runId,
+                    methodInfo = methodInfo,
+                )
+
+            val completion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs =
+                                listOf(
+                                    initializeWorkflowJob(workflowType = "PatchedAtStartWorkflow"),
+                                    notifyHasPatchJob("my-patch"),
+                                ),
+                            isReplaying = true,
+                        ),
+                    ).completion
+
+            assertTrue(completion.hasSuccessful())
+            assertEquals(
+                true,
+                workflow.sawPatch,
+                "patched() before first suspension must see the bundled NotifyHasPatch on replay",
+            )
+        }
+
+    @com.surrealdev.temporal.annotation.Workflow("DeprecatePatchWorkflow")
+    class DeprecatePatchWorkflow {
+        @com.surrealdev.temporal.annotation.WorkflowRun
+        suspend fun com.surrealdev.temporal.workflow.WorkflowContext.run(): String {
+            deprecatePatch("my-old-patch")
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    @Test
+    fun `deprecatePatch emits deprecated SetPatchMarker command`() =
+        runTest {
+            val workflow = DeprecatePatchWorkflow()
+            val runMethod =
+                DeprecatePatchWorkflow::class
+                    .members
+                    .first { it.name == "run" } as KFunction<*>
+            val methodInfo =
+                WorkflowMethodInfo(
+                    workflowType = "DeprecatePatchWorkflow",
+                    runMethod = runMethod,
+                    workflowClass = DeprecatePatchWorkflow::class,
+                    instanceFactory = { workflow },
+                    parameterTypes = emptyList(),
+                    returnType = typeOf<String>(),
+                    hasContextReceiver = true,
+                    isSuspend = true,
+                )
+            val runId = "test-run-${UUID.randomUUID()}"
+            val executor = createTestWorkflowExecutor(runId = runId, methodInfo = methodInfo)
+
+            val completion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(initializeWorkflowJob(workflowType = "DeprecatePatchWorkflow")),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(completion.hasSuccessful())
+            val marker =
+                completion.successful.commandsList
+                    .single { it.hasSetPatchMarker() }
+                    .setPatchMarker
+            assertEquals("my-old-patch", marker.patchId)
+            assertTrue(marker.deprecated, "SetPatchMarker should be marked deprecated")
+        }
+
+    // ================================================================
     // Helper Methods
     // ================================================================
 
-    private fun createTestExecutor(): WorkflowExecutor {
-        val dummyMethod =
-            this::class
-                .members
-                .first { it.name == "createTestExecutor" } as KFunction<*>
-
-        val testInstance = this
-        val workflowMethodInfo =
-            WorkflowMethodInfo(
-                workflowType = "TestWorkflow",
-                runMethod = dummyMethod,
-                workflowClass = this::class,
-                instanceFactory = { testInstance },
-                parameterTypes = emptyList(),
-                returnType = typeOf<Unit>(),
-                hasContextReceiver = false,
-                isSuspend = false,
-            )
-
-        return createTestWorkflowExecutor(methodInfo = workflowMethodInfo)
-    }
+    private fun createTestExecutor(): WorkflowExecutor =
+        com.surrealdev.temporal.testing
+            .createIdleTestWorkflowExecutor()
 }

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/RemoteActivityHandleImplTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/RemoteActivityHandleImplTest.kt
@@ -637,7 +637,7 @@ class RemoteActivityHandleImplTest {
     }
 
     @Test
-    fun `cancel with ABANDON type does not send command`() {
+    fun `cancel with ABANDON type sends command`() {
         val state = WorkflowState("test-run-id")
         val handle =
             RemoteActivityHandleImpl(
@@ -654,10 +654,15 @@ class RemoteActivityHandleImplTest {
 
         handle.cancel("abandon test")
 
-        // Should NOT have added any command
-        assertFalse(state.hasCommands())
+        // The cancel command must still be sent - Core SDK's activity state machine
+        // handles ABANDON by resolving the activity as cancelled immediately without
+        // asking the server to cancel. Without the command, result() would wait for
+        // the activity's natural resolution.
+        assertTrue(state.hasCommands())
+        val commands = state.drainCommands()
+        assertEquals(1, commands.size)
+        assertTrue(commands.first().hasRequestCancelActivity())
 
-        // But flag should be set
         assertTrue(handle.isCancellationRequested)
     }
 

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/TimerCancellationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/TimerCancellationTest.kt
@@ -1,0 +1,284 @@
+package com.surrealdev.temporal.workflow.internal
+
+import com.surrealdev.temporal.annotation.Workflow
+import com.surrealdev.temporal.annotation.WorkflowRun
+import com.surrealdev.temporal.serialization.CompositePayloadSerializer
+import com.surrealdev.temporal.testing.ProtoTestHelpers.createActivation
+import com.surrealdev.temporal.testing.ProtoTestHelpers.fireTimerJob
+import com.surrealdev.temporal.testing.ProtoTestHelpers.initializeWorkflowJob
+import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.workflow.WorkflowContext
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.reflect.KFunction
+import kotlin.reflect.typeOf
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Cancelling a sleeping coroutine must emit a CancelTimer command, otherwise the
+ * server-side timer leaks: it fires later, causing a pointless workflow task
+ * (and the pending map entry lingers). Mirrors the Python SDK, which emits
+ * cancel_timer from the sleep future's done-callback when cancelled.
+ */
+class TimerCancellationTest {
+    private val serializer = CompositePayloadSerializer.default()
+
+    /**
+     * Main coroutine sleeps 1s (timer A); a child coroutine sleeps 10s via
+     * [WorkflowContext.sleep] (timer B). When timer A fires, the child is cancelled -
+     * the SDK must emit CancelTimer for timer B.
+     */
+    @Workflow("CancelSleepWorkflow")
+    class CancelSleepWorkflow {
+        var sleeper: Job? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            sleeper = launch { sleep(10.seconds) }
+            sleep(1.seconds)
+            sleeper!!.cancel()
+            sleeper!!.join()
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    /**
+     * Same shape but the child uses kotlinx [delay] (the continuation-based timer path).
+     */
+    @Workflow("CancelDelayWorkflow")
+    class CancelDelayWorkflow {
+        var sleeper: Job? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            sleeper = launch { delay(10.seconds) }
+            sleep(1.seconds)
+            sleeper!!.cancel()
+            sleeper!!.join()
+            awaitCondition { false }
+            return "done"
+        }
+    }
+
+    private data class Fixture(
+        val executor: WorkflowExecutor,
+        val runId: String,
+    )
+
+    private suspend inline fun <reified T : Any> start(
+        workflowType: String,
+    ): Pair<Fixture, List<coresdk.workflow_commands.WorkflowCommands.WorkflowCommand>> {
+        val workflow = T::class.constructors.first().call()
+        val runMethod = T::class.members.first { it.name == "run" } as KFunction<*>
+        val methodInfo =
+            WorkflowMethodInfo(
+                workflowType = workflowType,
+                runMethod = runMethod,
+                workflowClass = T::class,
+                instanceFactory = { workflow },
+                parameterTypes = emptyList(),
+                returnType = typeOf<String>(),
+                hasContextReceiver = true,
+                isSuspend = true,
+            )
+        val runId = "test-run-${UUID.randomUUID()}"
+        val executor = createTestWorkflowExecutor(runId = runId, methodInfo = methodInfo, serializer = serializer)
+        val completion =
+            executor
+                .activate(
+                    createActivation(
+                        runId = runId,
+                        jobs = listOf(initializeWorkflowJob(workflowType = workflowType)),
+                        isReplaying = false,
+                    ),
+                ).completion
+        assertTrue(completion.hasSuccessful())
+        return Fixture(executor, runId) to completion.successful.commandsList
+    }
+
+    private suspend fun fireTimer(
+        fixture: Fixture,
+        seq: Int,
+    ): List<coresdk.workflow_commands.WorkflowCommands.WorkflowCommand> {
+        val completion =
+            fixture.executor
+                .activate(
+                    createActivation(
+                        runId = fixture.runId,
+                        jobs = listOf(fireTimerJob(seq)),
+                        isReplaying = false,
+                    ),
+                ).completion
+        assertTrue(completion.hasSuccessful())
+        return completion.successful.commandsList
+    }
+
+    @Test
+    fun `cancelling a sleeping coroutine emits CancelTimer`() =
+        runTest {
+            val (fixture, initCommands) = start<CancelSleepWorkflow>("CancelSleepWorkflow")
+
+            val timers = initCommands.filter { it.hasStartTimer() }
+            assertEquals(2, timers.size, "expected two StartTimer commands, got: $initCommands")
+            val shortTimer = timers.single { it.startTimer.startToFireTimeout.seconds == 1L }
+            val longTimer = timers.single { it.startTimer.startToFireTimeout.seconds == 10L }
+
+            val commands = fireTimer(fixture, shortTimer.startTimer.seq)
+
+            val cancelCommands = commands.filter { it.hasCancelTimer() }
+            assertEquals(1, cancelCommands.size, "expected a CancelTimer command, got: $commands")
+            assertEquals(longTimer.startTimer.seq, cancelCommands.single().cancelTimer.seq)
+        }
+
+    @Test
+    fun `cancelling a delayed coroutine emits CancelTimer`() =
+        runTest {
+            val (fixture, initCommands) = start<CancelDelayWorkflow>("CancelDelayWorkflow")
+
+            val timers = initCommands.filter { it.hasStartTimer() }
+            assertEquals(2, timers.size, "expected two StartTimer commands, got: $initCommands")
+            val shortTimer = timers.single { it.startTimer.startToFireTimeout.seconds == 1L }
+            val longTimer = timers.single { it.startTimer.startToFireTimeout.seconds == 10L }
+
+            val commands = fireTimer(fixture, shortTimer.startTimer.seq)
+
+            val cancelCommands = commands.filter { it.hasCancelTimer() }
+            assertEquals(1, cancelCommands.size, "expected a CancelTimer command, got: $commands")
+            assertEquals(longTimer.startTimer.seq, cancelCommands.single().cancelTimer.seq)
+        }
+
+    @Workflow("SleepSummaryWorkflow")
+    class SleepSummaryWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            sleep(5.seconds, summary = "waiting for approval window")
+            return "done"
+        }
+    }
+
+    @Test
+    fun `sleep summary is carried as user metadata on the StartTimer command`() =
+        runTest {
+            val (_, initCommands) = start<SleepSummaryWorkflow>("SleepSummaryWorkflow")
+
+            val timerCommand = initCommands.single { it.hasStartTimer() }
+            assertTrue(timerCommand.hasUserMetadata(), "StartTimer should carry user metadata")
+            assertTrue(
+                timerCommand.userMetadata.summary.data
+                    .toStringUtf8()
+                    .contains("waiting for approval window"),
+            )
+        }
+
+    @Workflow("AwaitConditionSummaryWorkflow")
+    class AwaitConditionSummaryWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            awaitCondition(timeout = 5.seconds, timeoutSummary = "waiting for flag") { false }
+            return "done"
+        }
+    }
+
+    @Test
+    fun `awaitCondition timeoutSummary is carried as user metadata on the timeout timer`() =
+        runTest {
+            val (_, initCommands) = start<AwaitConditionSummaryWorkflow>("AwaitConditionSummaryWorkflow")
+
+            val timerCommand = initCommands.single { it.hasStartTimer() }
+            assertTrue(timerCommand.hasUserMetadata(), "timeout timer should carry user metadata")
+            assertTrue(
+                timerCommand.userMetadata.summary.data
+                    .toStringUtf8()
+                    .contains("waiting for flag"),
+            )
+        }
+
+    @Workflow("AwaitConditionNoSummaryWorkflow")
+    class AwaitConditionNoSummaryWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            awaitCondition(timeout = 5.seconds) { false }
+            return "done"
+        }
+    }
+
+    @Test
+    fun `awaitCondition without summary emits a plain timeout timer`() =
+        runTest {
+            val (_, initCommands) = start<AwaitConditionNoSummaryWorkflow>("AwaitConditionNoSummaryWorkflow")
+
+            val timerCommand = initCommands.single { it.hasStartTimer() }
+            assertTrue(!timerCommand.hasUserMetadata(), "no summary means no user metadata")
+        }
+
+    @Test
+    fun `workflow completion does not emit CancelTimer for pending timers`() =
+        runTest {
+            // A workflow that completes while a background sleep is still pending must NOT
+            // emit CancelTimer commands - histories recorded before/after this behavior
+            // must replay identically, and the server drops timers on completion anyway.
+            @Workflow("CompleteWithPendingTimerWorkflow")
+            class CompleteWithPendingTimerWorkflow {
+                @WorkflowRun
+                suspend fun WorkflowContext.run(): String {
+                    launch { sleep(10.seconds) }
+                    sleep(1.seconds)
+                    return "done"
+                }
+            }
+
+            val workflow = CompleteWithPendingTimerWorkflow()
+            val runMethod =
+                CompleteWithPendingTimerWorkflow::class
+                    .members
+                    .first { it.name == "run" } as KFunction<*>
+            val methodInfo =
+                WorkflowMethodInfo(
+                    workflowType = "CompleteWithPendingTimerWorkflow",
+                    runMethod = runMethod,
+                    workflowClass = CompleteWithPendingTimerWorkflow::class,
+                    instanceFactory = { workflow },
+                    parameterTypes = emptyList(),
+                    returnType = typeOf<String>(),
+                    hasContextReceiver = true,
+                    isSuspend = true,
+                )
+            val runId = "test-run-${UUID.randomUUID()}"
+            val executor = createTestWorkflowExecutor(runId = runId, methodInfo = methodInfo, serializer = serializer)
+            val initCompletion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(initializeWorkflowJob(workflowType = "CompleteWithPendingTimerWorkflow")),
+                            isReplaying = false,
+                        ),
+                    ).completion
+            val shortTimerSeq =
+                initCompletion.successful.commandsList
+                    .single { it.hasStartTimer() && it.startTimer.startToFireTimeout.seconds == 1L }
+                    .startTimer.seq
+
+            val completion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(fireTimerJob(shortTimerSeq)),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(completion.hasSuccessful())
+            val commands = completion.successful.commandsList
+            assertTrue(commands.any { it.hasCompleteWorkflowExecution() }, "expected workflow completion: $commands")
+            assertTrue(commands.none { it.hasCancelTimer() }, "must not cancel timers on completion: $commands")
+        }
+}

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/UpdateHandlerTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/UpdateHandlerTest.kt
@@ -694,8 +694,11 @@ class UpdateHandlerTest {
     // ================================================================
 
     @Test
-    fun `update handler exception returns rejected`() =
+    fun `update handler non-failure exception fails the workflow task`() =
         runTest {
+            // A plain RuntimeException from an ACCEPTED update handler is a bug, not a
+            // business failure: the workflow task must fail (retryable) rather than the
+            // update being permanently reported as rejected. Matches the Python SDK.
             val (executor, runId) = createInitializedExecutor(ThrowingUpdateWorkflow())
 
             val protocolId = "test-protocol-id"
@@ -713,13 +716,53 @@ class UpdateHandlerTest {
                 )
             val completion = executor.activate(updateActivation).completion
 
+            assertTrue(completion.hasFailed(), "expected workflow task failure, got: $completion")
+            assertTrue(
+                completion.failed.failure.message
+                    .contains("Update handler error"),
+            )
+        }
+
+    @Workflow("FailureTypedUpdateWorkflow")
+    class FailureTypedUpdateWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String = "done"
+
+        @Update("failingUpdate")
+        fun WorkflowContext.failingUpdate(): String =
+            throw com.surrealdev.temporal.common.exceptions.ApplicationFailure
+                .failure("update business failure", "UpdateError")
+    }
+
+    @Test
+    fun `update handler failure-typed exception rejects the update`() =
+        runTest {
+            // ApplicationFailure is an orderly business failure: the update resolves as
+            // rejected/failed and the workflow task itself succeeds.
+            val (executor, runId) = createInitializedExecutor(FailureTypedUpdateWorkflow())
+
+            val protocolId = "test-protocol-id"
+            val updateActivation =
+                createActivation(
+                    runId = runId,
+                    jobs =
+                        listOf(
+                            doUpdateJob(
+                                name = "failingUpdate",
+                                protocolInstanceId = protocolId,
+                                runValidator = false,
+                            ),
+                        ),
+                )
+            val completion = executor.activate(updateActivation).completion
+
             assertTrue(completion.hasSuccessful())
             val commands = completion.successful.commandsList
             val rejected = commands.find { it.hasUpdateResponse() && it.updateResponse.hasRejected() }
-            assertNotNull(rejected, "Update should be rejected when handler throws")
+            assertNotNull(rejected, "Failure-typed update exception should reject the update, got: $commands")
             assertTrue(
                 rejected.updateResponse.rejected.message
-                    .contains("Update failed"),
+                    .contains("update business failure"),
             )
         }
 

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/UpdateHandlerTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/UpdateHandlerTest.kt
@@ -766,6 +766,50 @@ class UpdateHandlerTest {
             )
         }
 
+    @Workflow("FatalValidatorWorkflow")
+    class FatalValidatorWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String = "done"
+
+        @UpdateValidator("fatalUpdate")
+        fun validateFatalUpdate(): Unit = throw OutOfMemoryError("simulated heap exhaustion")
+
+        @Update("fatalUpdate")
+        fun WorkflowContext.fatalUpdate(): String = "unreachable"
+    }
+
+    @Test
+    fun `fatal error during update validation fails the workflow task fatally`() =
+        runTest {
+            // An OutOfMemoryError during validation means the JVM is compromised: the
+            // worker must shut down, not report the update as permanently rejected.
+            val (executor, runId) = createInitializedExecutor(FatalValidatorWorkflow())
+
+            val protocolId = "test-protocol-id"
+            val updateActivation =
+                createActivation(
+                    runId = runId,
+                    jobs =
+                        listOf(
+                            doUpdateJob(
+                                name = "fatalUpdate",
+                                protocolInstanceId = protocolId,
+                                runValidator = true,
+                            ),
+                        ),
+                )
+            val dispatch = executor.activate(updateActivation)
+
+            assertTrue(
+                dispatch.completion.hasFailed(),
+                "expected workflow task failure, got: ${dispatch.completion}",
+            )
+            assertTrue(
+                dispatch.fatalError is OutOfMemoryError,
+                "expected OutOfMemoryError as fatalError, got: ${dispatch.fatalError}",
+            )
+        }
+
     @Test
     fun `unknown update type returns rejected immediately`() =
         runTest {

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowActivationProcessingTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowActivationProcessingTest.kt
@@ -10,13 +10,11 @@ import com.surrealdev.temporal.testing.ProtoTestHelpers.queryWorkflowJob
 import com.surrealdev.temporal.testing.ProtoTestHelpers.removeFromCacheJob
 import com.surrealdev.temporal.testing.ProtoTestHelpers.signalWorkflowJob
 import com.surrealdev.temporal.testing.ProtoTestHelpers.timestamp
-import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.testing.createIdleTestWorkflowExecutor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import java.util.UUID
-import kotlin.reflect.KFunction
-import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -511,26 +509,5 @@ class WorkflowActivationProcessingTest {
     // Helper Methods
     // ================================================================
 
-    private fun createTestExecutor(): WorkflowExecutor {
-        // Get a simple method for the WorkflowMethodInfo
-        val dummyMethod =
-            this::class
-                .members
-                .first { it.name == "createTestExecutor" } as KFunction<*>
-
-        val testInstance = this
-        val workflowMethodInfo =
-            WorkflowMethodInfo(
-                workflowType = "TestWorkflow",
-                runMethod = dummyMethod,
-                workflowClass = this::class,
-                instanceFactory = { testInstance },
-                parameterTypes = emptyList(),
-                returnType = typeOf<Unit>(),
-                hasContextReceiver = false,
-                isSuspend = false,
-            )
-
-        return createTestWorkflowExecutor(methodInfo = workflowMethodInfo)
-    }
+    private fun createTestExecutor(): WorkflowExecutor = createIdleTestWorkflowExecutor()
 }

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowCancellationTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowCancellationTest.kt
@@ -1,0 +1,190 @@
+package com.surrealdev.temporal.workflow.internal
+
+import com.surrealdev.temporal.annotation.Workflow
+import com.surrealdev.temporal.annotation.WorkflowRun
+import com.surrealdev.temporal.serialization.CompositePayloadSerializer
+import com.surrealdev.temporal.testing.ProtoTestHelpers.cancelWorkflowJob
+import com.surrealdev.temporal.testing.ProtoTestHelpers.createActivation
+import com.surrealdev.temporal.testing.ProtoTestHelpers.initializeWorkflowJob
+import com.surrealdev.temporal.testing.ProtoTestHelpers.resolveActivityJobCompleted
+import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.workflow.ActivityOptions
+import com.surrealdev.temporal.workflow.WorkflowContext
+import com.surrealdev.temporal.workflow.result
+import com.surrealdev.temporal.workflow.startActivity
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for the workflow cancellation model:
+ * - the CancelWorkflow reason is preserved and observable
+ * - cancellation is catchable, and `withContext(NonCancellable)` allows post-cancel
+ *   cleanup work (e.g. a cleanup activity) before the workflow reports cancelled
+ */
+class WorkflowCancellationTest {
+    private val serializer = CompositePayloadSerializer.default()
+
+    @Workflow("CancelReasonWorkflow")
+    class CancelReasonWorkflow {
+        var caughtMessage: String? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            try {
+                sleep(30.seconds)
+            } catch (e: CancellationException) {
+                caughtMessage = e.message
+                throw e
+            }
+            return "done"
+        }
+    }
+
+    @Workflow("CancelCleanupWorkflow")
+    class CancelCleanupWorkflow {
+        var cleanupResult: String? = null
+
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            try {
+                sleep(30.seconds)
+            } catch (e: CancellationException) {
+                withContext(NonCancellable) {
+                    cleanupResult =
+                        startActivity(
+                            activityType = "cleanup",
+                            options = ActivityOptions(startToCloseTimeout = 30.seconds),
+                        ).result()
+                }
+                throw e
+            }
+            return "done"
+        }
+    }
+
+    private suspend inline fun <reified T : Any> init(workflowType: String): Triple<WorkflowExecutor, String, T> {
+        val workflow = T::class.constructors.first().call()
+        val runMethod = T::class.members.first { it.name == "run" } as KFunction<*>
+        val methodInfo =
+            WorkflowMethodInfo(
+                workflowType = workflowType,
+                runMethod = runMethod,
+                workflowClass = T::class,
+                instanceFactory = { workflow },
+                parameterTypes = emptyList(),
+                returnType = kotlin.reflect.typeOf<String>(),
+                hasContextReceiver = true,
+                isSuspend = true,
+            )
+        val runId = "test-run-${UUID.randomUUID()}"
+        val executor = createTestWorkflowExecutor(runId = runId, methodInfo = methodInfo, serializer = serializer)
+        executor.activate(
+            createActivation(
+                runId = runId,
+                jobs = listOf(initializeWorkflowJob(workflowType = workflowType)),
+                isReplaying = false,
+            ),
+        )
+        return Triple(executor, runId, workflow)
+    }
+
+    @Test
+    fun `cancellation reason is preserved and workflow reports cancelled`() =
+        runTest {
+            val (executor, runId, workflow) = init<CancelReasonWorkflow>("CancelReasonWorkflow")
+
+            val completion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(cancelWorkflowJob(reason = "user requested stop")),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(completion.hasSuccessful())
+            assertTrue(
+                completion.successful.commandsList.any { it.hasCancelWorkflowExecution() },
+                "expected CancelWorkflowExecution, got: ${completion.successful.commandsList}",
+            )
+            assertNotNull(workflow.caughtMessage, "workflow should be able to catch the cancellation")
+            assertTrue(
+                workflow.caughtMessage!!.contains("user requested stop"),
+                "cancel reason should be preserved, got: ${workflow.caughtMessage}",
+            )
+        }
+
+    @Test
+    fun `NonCancellable cleanup activity runs after cancellation before workflow cancels`() =
+        runTest {
+            val (executor, runId, workflow) = init<CancelCleanupWorkflow>("CancelCleanupWorkflow")
+
+            // Cancel: the workflow catches it and schedules a cleanup activity under
+            // NonCancellable. The completion must contain the ScheduleActivity command
+            // and must NOT yet be terminal.
+            val cancelCompletion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(cancelWorkflowJob(reason = "shutdown")),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(cancelCompletion.hasSuccessful())
+            val cancelCommands = cancelCompletion.successful.commandsList
+            val scheduleActivity = cancelCommands.find { it.hasScheduleActivity() }
+            assertNotNull(scheduleActivity, "cleanup activity should be scheduled, got: $cancelCommands")
+            assertTrue(
+                cancelCommands.none { it.hasCancelWorkflowExecution() },
+                "workflow must not cancel before cleanup completes: $cancelCommands",
+            )
+
+            // Resolve the cleanup activity - now the workflow rethrows and cancels
+            val resultPayload =
+                io.temporal.api.common.v1.Payload
+                    .newBuilder()
+                    .putMetadata(
+                        "encoding",
+                        com.google.protobuf.ByteString
+                            .copyFromUtf8("json/plain"),
+                    ).setData(
+                        com.google.protobuf.ByteString
+                            .copyFromUtf8("\"cleaned\""),
+                    ).build()
+            val finalCompletion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs =
+                                listOf(
+                                    resolveActivityJobCompleted(
+                                        scheduleActivity.scheduleActivity.seq,
+                                        com.surrealdev.temporal.common
+                                            .TemporalPayload(resultPayload),
+                                    ),
+                                ),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(finalCompletion.hasSuccessful())
+            assertTrue(
+                finalCompletion.successful.commandsList.any { it.hasCancelWorkflowExecution() },
+                "expected CancelWorkflowExecution after cleanup, got: ${finalCompletion.successful.commandsList}",
+            )
+            assertEquals("cleaned", workflow.cleanupResult)
+        }
+}

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowContextImplStartActivityTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowContextImplStartActivityTest.kt
@@ -1,5 +1,8 @@
 package com.surrealdev.temporal.workflow.internal
 
+import com.surrealdev.temporal.application.plugin.HookRegistry
+import com.surrealdev.temporal.application.plugin.HookRegistryImpl
+import com.surrealdev.temporal.application.plugin.interceptor.ScheduleActivity
 import com.surrealdev.temporal.common.RetryPolicy
 import com.surrealdev.temporal.common.TemporalPayload
 import com.surrealdev.temporal.serialization.CompositePayloadSerializer
@@ -10,6 +13,7 @@ import com.surrealdev.temporal.workflow.ActivityOptions
 import com.surrealdev.temporal.workflow.WorkflowInfo
 import com.surrealdev.temporal.workflow.startActivity
 import kotlinx.coroutines.Job
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -33,7 +37,7 @@ import kotlin.time.Instant
 class WorkflowContextImplStartActivityTest {
     private val serializer = CompositePayloadSerializer.default()
 
-    private fun createContext(): WorkflowContextImpl {
+    private fun createContext(hookRegistry: HookRegistry = HookRegistryImpl.EMPTY): WorkflowContextImpl {
         val state = WorkflowState("test-run-id")
         state.isReadOnly = false
         val info =
@@ -59,6 +63,7 @@ class WorkflowContextImplStartActivityTest {
             parentJob = Job(),
             handlerJob = Job(),
             parentScope = taskQueueScope,
+            hookRegistry = hookRegistry,
         )
     }
 
@@ -328,12 +333,13 @@ class WorkflowContextImplStartActivityTest {
                 }
 
             assertTrue(exception.message!!.contains("priority"))
-            assertTrue(exception.message!!.contains("0-100"))
         }
 
     @Test
-    fun `startActivity validates priority maximum is 100`() =
+    fun `startActivity accepts priority keys above the default server range`() =
         runWorkflowUnitTest {
+            // Priority keys are passed through as-is; the server's supported range is
+            // configurable (1-5 by default), so the SDK only rejects negative values.
             val context = createContext()
             val options =
                 ActivityOptions(
@@ -341,13 +347,8 @@ class WorkflowContextImplStartActivityTest {
                     priority = 101,
                 )
 
-            val exception =
-                assertFailsWith<IllegalArgumentException> {
-                    context.startActivity("TestActivity", options)
-                }
-
-            assertTrue(exception.message!!.contains("priority"))
-            assertTrue(exception.message!!.contains("0-100"))
+            val handle = context.startActivity("TestActivity", options)
+            assertNotNull(handle)
         }
 
     @Test
@@ -792,17 +793,82 @@ class WorkflowContextImplStartActivityTest {
             val context = createContext()
             val state = getState(context)
 
-            // Test with priority = 50
+            // Priority key is passed through unchanged (lower key = higher priority,
+            // 0 = unset/server default)
             val options =
                 ActivityOptions(
                     startToCloseTimeout = 30.seconds,
-                    priority = 50,
+                    priority = 3,
                 )
 
             context.startActivity("TestActivity", options)
 
             val command = getCommands(state)[0].scheduleActivity
             assertTrue(command.hasPriority())
-            assertEquals(50, command.priority.priorityKey)
+            assertEquals(3, command.priority.priorityKey)
+        }
+
+    // ========== Category 10: User Metadata (Summary) ==========
+
+    @Test
+    fun `ScheduleActivity command sets summary as user metadata`() =
+        runWorkflowUnitTest {
+            val context = createContext()
+            val state = getState(context)
+
+            val options =
+                ActivityOptions(
+                    startToCloseTimeout = 30.seconds,
+                    summary = "Greets the user",
+                )
+
+            context.startActivity("TestActivity", options)
+
+            val command = getCommands(state)[0]
+            assertTrue(command.hasUserMetadata(), "WorkflowCommand should carry user metadata")
+            assertTrue(
+                command.userMetadata.summary.data
+                    .toStringUtf8()
+                    .contains("Greets the user"),
+            )
+        }
+
+    @Test
+    fun `ScheduleActivity command omits user metadata when summary is not set`() =
+        runWorkflowUnitTest {
+            val context = createContext()
+            val state = getState(context)
+
+            context.startActivity("TestActivity", ActivityOptions(startToCloseTimeout = 30.seconds))
+
+            val command = getCommands(state)[0]
+            assertTrue(!command.hasUserMetadata())
+        }
+
+    // ========== Category 11: Interceptor Headers ==========
+
+    @Test
+    fun `interceptor-added headers are propagated to ScheduleActivity command`() =
+        runWorkflowUnitTest {
+            val hookRegistry = HookRegistryImpl()
+            hookRegistry.register(ScheduleActivity) { input, proceed ->
+                input.headers["trace-id"] = serializer.serialize(typeOf<String>(), "abc-123")
+                proceed(input)
+            }
+            val context = createContext(hookRegistry)
+            val state = getState(context)
+
+            val options =
+                ActivityOptions(
+                    startToCloseTimeout = 30.seconds,
+                    headers = mapOf("from-options" to serializer.serialize(typeOf<String>(), "opt-value")),
+                )
+
+            context.startActivity("TestActivity", options)
+
+            val command = getCommands(state)[0].scheduleActivity
+            assertEquals(2, command.headersMap.size)
+            assertTrue(command.headersMap.containsKey("trace-id"), "interceptor header should be present")
+            assertTrue(command.headersMap.containsKey("from-options"), "options header should be preserved")
         }
 }

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureHandlingTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureHandlingTest.kt
@@ -7,6 +7,7 @@ import com.surrealdev.temporal.client.history.TemporalHistoryEvent
 import com.surrealdev.temporal.client.startWorkflow
 import com.surrealdev.temporal.common.exceptions.ApplicationFailure
 import com.surrealdev.temporal.testing.assertHistory
+import com.surrealdev.temporal.testing.awaitHistory
 import com.surrealdev.temporal.testing.runTemporalTest
 import com.surrealdev.temporal.workflow.WorkflowContext
 import com.surrealdev.temporal.workflow.result
@@ -618,17 +619,9 @@ class WorkflowFailureHandlingTest {
 
             // A plain NPE is a bug, not a business failure: the workflow TASK fails
             // (retryable) and the workflow stays running rather than failing permanently.
-            val deadline = System.currentTimeMillis() + 10_000
-            var sawTaskFailure = false
-            while (System.currentTimeMillis() < deadline) {
-                val history = handle.getHistory()
-                if (history.filterByType<TemporalHistoryEvent.WorkflowTaskFailed>().isNotEmpty()) {
-                    sawTaskFailure = true
-                    break
-                }
-                kotlinx.coroutines.delay(200.milliseconds)
+            handle.awaitHistory(description = "a WorkflowTaskFailed event") {
+                it.filterByType<TemporalHistoryEvent.WorkflowTaskFailed>().isNotEmpty()
             }
-            assertTrue(sawTaskFailure, "Expected a WorkflowTaskFailed event in history")
 
             val description = handle.describe()
             assertEquals(

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureHandlingTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureHandlingTest.kt
@@ -3,7 +3,9 @@ package com.surrealdev.temporal.workflow.internal
 import com.surrealdev.temporal.annotation.Workflow
 import com.surrealdev.temporal.annotation.WorkflowRun
 import com.surrealdev.temporal.application.taskQueue
+import com.surrealdev.temporal.client.history.TemporalHistoryEvent
 import com.surrealdev.temporal.client.startWorkflow
+import com.surrealdev.temporal.common.exceptions.ApplicationFailure
 import com.surrealdev.temporal.testing.assertHistory
 import com.surrealdev.temporal.testing.runTemporalTest
 import com.surrealdev.temporal.workflow.WorkflowContext
@@ -22,7 +24,9 @@ import kotlin.time.Duration.Companion.seconds
  * Integration tests for workflow failure and cancellation handling.
  *
  * These tests verify that:
- * - Workflow exceptions are converted to Temporal workflow failures
+ * - Failure-typed exceptions ([ApplicationFailure]) fail the workflow permanently
+ * - Non-failure exceptions (bugs) fail the workflow TASK and leave the workflow
+ *   running/retryable, matching mainline SDK semantics
  * - Exceptions don't propagate up to the application/worker
  * - Cancellations are handled correctly
  * - Multiple workflows can fail independently without affecting each other
@@ -30,29 +34,29 @@ import kotlin.time.Duration.Companion.seconds
  */
 class WorkflowFailureHandlingTest {
     /**
-     * Workflow that throws an exception immediately.
+     * Workflow that throws a failure-typed exception immediately.
      */
     @Workflow("FailingWorkflow")
     class FailingWorkflow {
         @WorkflowRun
         suspend fun WorkflowContext.run(message: String): String =
-            throw IllegalStateException("Workflow failed: $message")
+            throw ApplicationFailure.failure("Workflow failed: $message")
     }
 
     /**
-     * Workflow that throws an exception after some work.
+     * Workflow that throws a failure-typed exception after some work.
      */
     @Workflow("FailAfterSleepWorkflow")
     class FailAfterSleepWorkflow {
         @WorkflowRun
         suspend fun WorkflowContext.run(): String {
             sleep(50.milliseconds)
-            throw RuntimeException("Failed after sleep")
+            throw ApplicationFailure.failure("Failed after sleep")
         }
     }
 
     /**
-     * Workflow that throws an exception in an async block.
+     * Workflow that throws a failure-typed exception in an async block.
      */
     @Workflow("FailInAsyncWorkflow")
     class FailInAsyncWorkflow {
@@ -61,14 +65,14 @@ class WorkflowFailureHandlingTest {
             val deferred =
                 async {
                     sleep(30.milliseconds)
-                    throw IllegalArgumentException("Async block failed")
+                    throw ApplicationFailure.failure("Async block failed")
                 }
             deferred.await()
         }
     }
 
     /**
-     * Workflow that launches a coroutine that fails.
+     * Workflow that launches a coroutine that fails with a failure-typed exception.
      */
     @Workflow("FailInLaunchWorkflow")
     class FailInLaunchWorkflow {
@@ -77,7 +81,7 @@ class WorkflowFailureHandlingTest {
             val job =
                 launch {
                     sleep(30.milliseconds)
-                    throw IllegalStateException("Launched coroutine failed")
+                    throw ApplicationFailure.failure("Launched coroutine failed")
                 }
             job.join()
             return "Should not reach here"
@@ -121,7 +125,7 @@ class WorkflowFailureHandlingTest {
             val deferred2 =
                 async {
                     sleep(50.milliseconds) // Fires later - deterministic order
-                    throw IllegalStateException("One async failed")
+                    throw ApplicationFailure.failure("One async failed")
                 }
 
             // deferred1 completes successfully first
@@ -133,21 +137,17 @@ class WorkflowFailureHandlingTest {
     }
 
     /**
-     * Workflow that throws a custom exception with detailed message.
+     * Workflow that throws a custom-typed failure with a cause chain.
      */
     @Workflow("CustomExceptionWorkflow")
     class CustomExceptionWorkflow {
-        class CustomWorkflowException(
-            message: String,
-            cause: Throwable? = null,
-        ) : Exception(message, cause)
-
         @WorkflowRun
         suspend fun WorkflowContext.run(): String {
             sleep(25.milliseconds)
-            throw CustomWorkflowException(
-                "Custom error with context",
-                IllegalArgumentException("Root cause"),
+            throw ApplicationFailure.failure(
+                message = "Custom error with context",
+                type = "CustomWorkflowError",
+                cause = IllegalArgumentException("Root cause"),
             )
         }
     }
@@ -589,7 +589,7 @@ class WorkflowFailureHandlingTest {
     // ================================================================
 
     @Test
-    fun `workflow with null pointer exception is handled`() =
+    fun `workflow with null pointer exception fails the task and stays running`() =
         runTemporalTest {
             @Workflow("NullPointerWorkflow")
             class NullPointerWorkflow {
@@ -616,16 +616,28 @@ class WorkflowFailureHandlingTest {
                     taskQueue = taskQueue,
                 )
 
-            val exception =
-                assertFailsWith<Exception> {
-                    handle.result(timeout = 10.seconds)
+            // A plain NPE is a bug, not a business failure: the workflow TASK fails
+            // (retryable) and the workflow stays running rather than failing permanently.
+            val deadline = System.currentTimeMillis() + 10_000
+            var sawTaskFailure = false
+            while (System.currentTimeMillis() < deadline) {
+                val history = handle.getHistory()
+                if (history.filterByType<TemporalHistoryEvent.WorkflowTaskFailed>().isNotEmpty()) {
+                    sawTaskFailure = true
+                    break
                 }
-
-            // Should capture the NPE in the failure
-            println("NPE captured as: ${exception.message}")
-
-            handle.assertHistory {
-                failed()
+                kotlinx.coroutines.delay(200.milliseconds)
             }
+            assertTrue(sawTaskFailure, "Expected a WorkflowTaskFailed event in history")
+
+            val description = handle.describe()
+            assertEquals(
+                com.surrealdev.temporal.client.WorkflowExecutionStatus.RUNNING,
+                description.status,
+                "Workflow should still be running after a task failure",
+            )
+
+            // Clean up the perpetually-retrying workflow
+            handle.terminate("test cleanup")
         }
 }

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureSemanticsTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowFailureSemanticsTest.kt
@@ -1,0 +1,199 @@
+package com.surrealdev.temporal.workflow.internal
+
+import com.surrealdev.temporal.annotation.Workflow
+import com.surrealdev.temporal.annotation.WorkflowRun
+import com.surrealdev.temporal.common.exceptions.ApplicationFailure
+import com.surrealdev.temporal.serialization.CompositePayloadSerializer
+import com.surrealdev.temporal.testing.ProtoTestHelpers.createActivation
+import com.surrealdev.temporal.testing.ProtoTestHelpers.initializeWorkflowJob
+import com.surrealdev.temporal.testing.createTestWorkflowExecutor
+import com.surrealdev.temporal.workflow.WorkflowContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for workflow failure semantics, matching mainline Temporal SDK behavior:
+ *
+ * - Failure-typed exceptions (ApplicationFailure, activity/child workflow failures, etc.)
+ *   fail the WORKFLOW (permanent, FailWorkflowExecution command).
+ * - All other exceptions (bugs: NPE, IllegalStateException, ...) fail the workflow TASK
+ *   (retryable, completion.failed) so the workflow can recover after a worker fix/redeploy.
+ */
+class WorkflowFailureSemanticsTest {
+    private val serializer = CompositePayloadSerializer.default()
+
+    @Workflow("PlainExceptionWorkflow")
+    class PlainExceptionWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String = throw IllegalStateException("some bug in workflow code")
+    }
+
+    @Workflow("ApplicationFailureWorkflow")
+    class ApplicationFailureWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String = throw ApplicationFailure.failure("business failure", "MyFailure")
+    }
+
+    @Workflow("PlainExceptionInAsyncWorkflow")
+    class PlainExceptionInAsyncWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            val deferred =
+                async {
+                    throw IllegalArgumentException("bug inside async block")
+                }
+            deferred.await()
+            return "unreachable"
+        }
+    }
+
+    @Workflow("SleepThenFailWorkflow")
+    class SleepThenFailWorkflow {
+        @WorkflowRun
+        suspend fun WorkflowContext.run(): String {
+            sleep(5.seconds)
+            throw IllegalStateException("bug after sleep")
+        }
+    }
+
+    private suspend inline fun <reified T : Any> initWorkflow(
+        workflowType: String,
+    ): coresdk.workflow_completion.WorkflowCompletion.WorkflowActivationCompletion {
+        val workflow = T::class.constructors.first().call()
+        val runMethod = T::class.members.first { it.name == "run" } as KFunction<*>
+
+        val methodInfo =
+            WorkflowMethodInfo(
+                workflowType = workflowType,
+                runMethod = runMethod,
+                workflowClass = T::class,
+                instanceFactory = { workflow },
+                parameterTypes = emptyList(),
+                returnType = runMethod.returnType,
+                hasContextReceiver = true,
+                isSuspend = true,
+            )
+
+        val runId = "test-run-${UUID.randomUUID()}"
+        val executor =
+            createTestWorkflowExecutor(
+                runId = runId,
+                methodInfo = methodInfo,
+                serializer = serializer,
+            )
+
+        return executor
+            .activate(
+                createActivation(
+                    runId = runId,
+                    jobs = listOf(initializeWorkflowJob(workflowType = workflowType)),
+                    isReplaying = false,
+                ),
+            ).completion
+    }
+
+    @Test
+    fun `plain exception fails the workflow task not the workflow`() =
+        runTest {
+            val completion = initWorkflow<PlainExceptionWorkflow>("PlainExceptionWorkflow")
+
+            // A non-failure-typed exception is a bug, not a business failure: it must fail
+            // the workflow TASK (retryable) so the workflow survives until the worker is fixed.
+            assertTrue(completion.hasFailed(), "expected workflow task failure completion")
+            assertTrue(
+                completion.failed.failure.message
+                    .contains("some bug in workflow code"),
+            )
+            assertFalse(completion.hasSuccessful())
+        }
+
+    @Test
+    fun `ApplicationFailure fails the workflow permanently`() =
+        runTest {
+            val completion = initWorkflow<ApplicationFailureWorkflow>("ApplicationFailureWorkflow")
+
+            assertTrue(completion.hasSuccessful())
+            val failCommand =
+                completion.successful.commandsList.single { it.hasFailWorkflowExecution() }
+            assertEquals("MyFailure", failCommand.failWorkflowExecution.failure.applicationFailureInfo.type)
+        }
+
+    @Test
+    fun `plain exception inside async block fails the workflow task`() =
+        runTest {
+            val completion = initWorkflow<PlainExceptionInAsyncWorkflow>("PlainExceptionInAsyncWorkflow")
+
+            // Structured-concurrency cancellation wrappers must be unwrapped to the root
+            // cause before deciding, and the root cause here is a plain exception.
+            assertTrue(completion.hasFailed(), "expected workflow task failure completion")
+            assertTrue(
+                completion.failed.failure.message
+                    .contains("bug inside async block"),
+            )
+        }
+
+    @Test
+    fun `plain exception after a command was scheduled still fails the task`() =
+        runTest {
+            // Workflow sleeps first (StartTimer command in first activation), then throws
+            // when the timer fires. The second activation must be a task failure.
+            val workflow = SleepThenFailWorkflow()
+            val runMethod = SleepThenFailWorkflow::class.members.first { it.name == "run" } as KFunction<*>
+            val methodInfo =
+                WorkflowMethodInfo(
+                    workflowType = "SleepThenFailWorkflow",
+                    runMethod = runMethod,
+                    workflowClass = SleepThenFailWorkflow::class,
+                    instanceFactory = { workflow },
+                    parameterTypes = emptyList(),
+                    returnType = runMethod.returnType,
+                    hasContextReceiver = true,
+                    isSuspend = true,
+                )
+            val runId = "test-run-${UUID.randomUUID()}"
+            val executor =
+                createTestWorkflowExecutor(
+                    runId = runId,
+                    methodInfo = methodInfo,
+                    serializer = serializer,
+                )
+
+            val initCompletion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs = listOf(initializeWorkflowJob(workflowType = "SleepThenFailWorkflow")),
+                            isReplaying = false,
+                        ),
+                    ).completion
+            assertTrue(initCompletion.hasSuccessful())
+            val timerSeq =
+                initCompletion.successful.commandsList
+                    .single { it.hasStartTimer() }
+                    .startTimer.seq
+
+            val fireCompletion =
+                executor
+                    .activate(
+                        createActivation(
+                            runId = runId,
+                            jobs =
+                                listOf(
+                                    com.surrealdev.temporal.testing.ProtoTestHelpers
+                                        .fireTimerJob(timerSeq),
+                                ),
+                            isReplaying = false,
+                        ),
+                    ).completion
+
+            assertTrue(fireCompletion.hasFailed(), "expected workflow task failure completion")
+        }
+}

--- a/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowStateTest.kt
+++ b/core/src/test/kotlin/com/surrealdev/temporal/workflow/internal/WorkflowStateTest.kt
@@ -558,7 +558,7 @@ class WorkflowStateTest {
         }
 
     @Test
-    fun `resolveActivity handles non-existent activity gracefully`() =
+    fun `resolveActivity throws for non-existent activity`() =
         runTest {
             val state = WorkflowState("test-run-id")
 
@@ -569,8 +569,11 @@ class WorkflowStateTest {
                     .setCompleted(completed)
                     .build()
 
-            // Should not throw for non-existent activity
-            state.resolveActivity(999, resolution)
+            // An unknown seq is a correlation bug: it must fail loudly (workflow task
+            // failure) rather than silently leaving the awaiting coroutine hung
+            assertFailsWith<IllegalStateException> {
+                state.resolveActivity(999, resolution)
+            }
         }
 
     @Test
@@ -1015,7 +1018,7 @@ class WorkflowStateTest {
         }
 
     @Test
-    fun `resolveActivity handles non-existent activity gracefully - no exception`() =
+    fun `resolveActivity throws for non-existent activity after other resolutions`() =
         runTest {
             val state = WorkflowState("test-run")
             state.isReadOnly = false
@@ -1027,8 +1030,10 @@ class WorkflowStateTest {
                     .setCompleted(completed)
                     .build()
 
-            // Should not throw for non-existent activity
-            state.resolveActivity(999, resolution)
+            // See above: unknown seqs must fail loudly, not hang the workflow
+            assertFailsWith<IllegalStateException> {
+                state.resolveActivity(999, resolution)
+            }
         }
 
     // ================================================================

--- a/docs/ACTIVITIES_IMPERATIVE.md
+++ b/docs/ACTIVITIES_IMPERATIVE.md
@@ -436,8 +436,9 @@ data class ActivityOptions(
     val taskQueue: String?,                  // Override task queue
     val retryPolicy: RetryPolicy?,           // Custom retry policy
     val cancellationType: ActivityCancellationType,  // How to handle cancellation
-    val priority: Int,                       // Scheduling priority (0-100)
+    val priority: Int,                       // Priority key (lower = higher priority, 0 = server default)
     val disableEagerExecution: Boolean,      // Disable eager execution
+    val summary: String?,                    // Single-line summary shown in the Temporal UI
 )
 ```
 

--- a/plugins/di/src/test/kotlin/com/surrealdev/temporal/dependencies/BasicDependencyInjectionTest.kt
+++ b/plugins/di/src/test/kotlin/com/surrealdev/temporal/dependencies/BasicDependencyInjectionTest.kt
@@ -1144,7 +1144,10 @@ class BasicDependencyInjectionTest {
             options: com.surrealdev.temporal.workflow.LocalActivityOptions,
         ): com.surrealdev.temporal.workflow.LocalActivityHandle = TODO("Not needed for DI tests")
 
-        override suspend fun sleep(duration: Duration) = TODO("Not needed for DI tests")
+        override suspend fun sleep(
+            duration: Duration,
+            summary: String?,
+        ) = TODO("Not needed for DI tests")
 
         override suspend fun awaitCondition(condition: () -> Boolean) = TODO("Not needed for DI tests")
 
@@ -1159,6 +1162,8 @@ class BasicDependencyInjectionTest {
         override fun randomUuid(): String = "mock-uuid"
 
         override fun patched(patchId: String): Boolean = true
+
+        override fun deprecatePatch(patchId: String) = Unit
 
         override fun isContinueAsNewSuggested(): Boolean = false
 


### PR DESCRIPTION
## Summary

A field-level cross-SDK review against [temporalio/sdk-python](https://github.com/temporalio/sdk-python) (which drives the same Rust Core) surfaced correctness bugs and semantic divergences. This PR fixes all of them, test-first for each behavior change. **686 core tests passing**, ktlint clean.

## ⚠️ Behavior changes (breaking)

**1. Plain exceptions fail the workflow *task*, not the workflow.**
Previously any exception thrown from workflow code emitted `FailWorkflowExecution` (permanent). Now only failure-typed exceptions (`ApplicationFailure`, activity/child/external failure exceptions, `WorkflowConditionTimeoutException`) fail the workflow; anything else (NPE, `IllegalStateException`, …) fails the workflow **task** — retryable, so the workflow survives a worker bug and recovers on redeploy. Matches Python/Java/.NET. Fatal `Error`s still shut down the worker.

> Migration: workflows that relied on `throw RuntimeException(...)` to fail permanently should throw `ApplicationFailure.failure(...)` instead. Existing test suites were updated accordingly.

**2. Priority semantics corrected.** `ActivityOptions.priority` was documented as "0–100, higher = first" but the proto key means **lower = higher priority, 0 = server default**. The key now passes through with corrected docs and validation (`>= 0`). Anyone setting a non-zero priority was previously getting the opposite of their intent.

**3. Accepted updates that throw non-failure exceptions fail the task** instead of being permanently reported rejected; validator state mutation fails the task. Failure-typed exceptions still reject the update.

## Bug fixes

- **ABANDON activity cancellation hung forever** — no cancel command was sent and the handle never resolved. Core owns ABANDON semantics (resolves immediately, no server round trip), so the command is now always sent.
- **Patch/init ordering** — `NotifyHasPatch` was applied *after* the workflow body first ran, so `patched()` before the first suspension returned a different value on replay (nondeterminism panic). Patches now process first, like Python's job sets.
- **Cancelled `sleep()`/`delay()` leaked server timers** — now emit `CancelTimer`, with guards so teardown/terminal completion never emit them (replay compatibility, tested).
- **Child workflow cancellation** — `cancel(reason)` silently dropped the reason; cancelling the coroutine awaiting a child result (`withTimeout { handle.result() }`) now cancels the child (Python `wait_for` parity), propagating the workflow's cancel reason.
- **Eviction ran workflow teardown on the poller thread**, violating the single-thread invariant — now routed through the workflow's own virtual thread, with a `[TKT1109]` drain-check warning for leaked coroutines.
- **Unmatched activity/child resolutions were silently ignored**, turning correlation bugs into permanently hung workflows — now fail the task loudly. Timer/external-signal resolutions stay tolerant where a cancel/fire race is legitimate (documented per site).
- **Buffered-signal replay** ran on the main job without the live-signal swallow-and-log wrapper — a throwing replayed handler could fail the workflow; now identical to live delivery.
- **Cancelling a pending external signal** now rescinds it with `CancelSignalWorkflow`.
- **Local activity args were codec-encoded twice** (2× cost; non-deterministic codecs produced mismatched retry payloads) — encoded once and reused; headers and summary are re-applied on cross-WFT backoff reschedules.
- **Continue-as-new with an empty search-attributes map cleared them** instead of inheriting.
- **Workflow cancel reason** is preserved, observable in the caught exception, and catch + `withContext(NonCancellable)` cleanup (e.g. a cleanup activity) before cancelling is now covered by activation-level tests.

## New API surface

- `ScheduleActivityInput.headers` for interceptors (merged with `options.headers`, interceptor wins).
- `summary` on `ActivityOptions`, `LocalActivityOptions`, `ChildWorkflowOptions`, `sleep(duration, summary)`, and `awaitCondition(timeout, timeoutSummary)` — all sent as `WorkflowCommand.user_metadata` for the Temporal UI.
- `ChildWorkflowOptions`: `cronSchedule`, `memo`, `versioningIntent`, `workflowTaskTimeout`, `priority`.
- `WorkflowContext.deprecatePatch(patchId)`.

## Perf

Single-pass activation job partitioning, debug logging gated behind `isDebugEnabled`, one shared `toProtoDuration` (was 4 copies), `NoOpCodec` fast path skipping the nested `runBlocking` per encode/decode, and `now()` keeps nanosecond precision.

## Known remaining gaps (intentional)

- Swallowing cancellation to complete a workflow normally is still unsupported (the main Job is poisoned once cancelled); catch-cleanup-then-cancel works and is tested. Full parity needs a cancellation-scope redesign.
- Per-activation batch codec encoding (Python's `encode_completion` model) remains a follow-up; remote codecs still run per-call on the workflow thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)